### PR TITLE
Fix namespace issue in opsrampmetricsfilter processor

### DIFF
--- a/processor/opsrampmetricsfilterprocessor/config.go
+++ b/processor/opsrampmetricsfilterprocessor/config.go
@@ -39,11 +39,9 @@ func (cfg *Config) Validate() error {
 	}
 
 	// Set namespace from environment variable if not already set
+	cfg.Namespace = os.Getenv("NAMESPACE")
 	if cfg.Namespace == "" {
-		cfg.Namespace = os.Getenv("NAMESPACE")
-		if cfg.Namespace == "" {
-			cfg.Namespace = "opsramp-agent"
-		}
+		cfg.Namespace = "opsramp-agent"
 	}
 
 	return nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When agent is installed in different namespace, this `opsrampmetricsfilterprocessor` is taking the default namespace `opsramp-agent`, hence throwing configmap not found error. This PR fixes this issue.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
