### PR TITLE
WIP - G2_Agent_20.0 - Improvements

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/header"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -160,7 +159,7 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		TelemetrySettings:       set,
 		FromBeginning:           startAtBeginning,
 		FingerprintSize:         int(c.FingerprintSize),
-		InitialBufferSize:       scanner.DefaultBufferSize,
+		InitialBufferSize:       c.InitialBufferSize,
 		MaxLogSize:              int(c.MaxLogSize),
 		Encoding:                enc,
 		SplitFunc:               splitFunc,

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	MaxBatches              int             `mapstructure:"max_batches,omitempty"`
 	StartAt                 string          `mapstructure:"start_at,omitempty"`
 	FingerprintSize         helper.ByteSize `mapstructure:"fingerprint_size,omitempty"`
+	InitialBufferSize       int             `yaml:"initial_buffer_size,omitempty"`
 	MaxLogSize              helper.ByteSize `mapstructure:"max_log_size,omitempty"`
 	Encoding                string          `mapstructure:"encoding,omitempty"`
 	SplitConfig             split.Config    `mapstructure:"multiline,omitempty"`

--- a/pkg/stanza/fileconsumer/internal/scanner/scanner.go
+++ b/pkg/stanza/fileconsumer/internal/scanner/scanner.go
@@ -11,7 +11,7 @@ import (
 	stanzaerrors "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 )
 
-const DefaultBufferSize = 16 * 1024
+const DefaultBufferSize = 1 * 1024 * 1024
 
 // Scanner is a scanner that maintains position
 type Scanner struct {

--- a/pkg/stanza/operator/input/windows/raw.go
+++ b/pkg/stanza/operator/input/windows/raw.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+)
+
+// EventRaw is the rendered xml of an event, however, its message is the original XML of the entire event.
+type EventRaw struct {
+	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
+	RenderedLevel string      `xml:"RenderingInfo>Level"`
+	Level         string      `xml:"System>Level"`
+	Body          string      `xml:"-"`
+}
+
+// parseTimestamp will parse the timestamp of the event.
+func (e *EventRaw) ParseTimestamp() time.Time {
+	if timestamp, err := time.Parse(time.RFC3339Nano, e.TimeCreated.SystemTime); err == nil {
+		return timestamp
+	}
+	return time.Now()
+}
+
+// parseRenderedSeverity will parse the severity of the event.
+func (e *EventRaw) ParseRenderedSeverity() entry.Severity {
+	switch e.RenderedLevel {
+	case "":
+		return e.ParseSeverity()
+	case "Critical":
+		return entry.Fatal
+	case "Error":
+		return entry.Error
+	case "Warning":
+		return entry.Warn
+	case "Information":
+		return entry.Info
+	default:
+		return entry.Default
+	}
+}
+
+// parseSeverity will parse the severity of the event when RenderingInfo is not populated
+func (e *EventRaw) ParseSeverity() entry.Severity {
+	switch e.Level {
+	case "1":
+		return entry.Fatal
+	case "2":
+		return entry.Error
+	case "3":
+		return entry.Warn
+	case "4":
+		return entry.Info
+	default:
+		return entry.Default
+	}
+}
+
+func (e *EventRaw) parseBody() string {
+	return e.Body
+}
+
+// unmarshalEventRaw will unmarshal EventRaw from xml bytes.
+func UnmarshalEventRaw(bytes []byte) (EventRaw, error) {
+	var eventRaw EventRaw
+	if err := xml.Unmarshal(bytes, &eventRaw); err != nil {
+		return EventRaw{}, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
+	}
+	eventRaw.Body = string(bytes)
+	return eventRaw, nil
+}

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -250,12 +250,12 @@ func (e Execution) asMap() map[string]any {
 	return result
 }
 
-// unmarshalEventXML will unmarshal EventXML from xml bytes.
-func unmarshalEventXML(bytes []byte) (*EventXML, error) {
-	var eventXML EventXML
+// UnmarshalEventXML will unmarshal EventXML from xml bytes.
+func UnmarshalEventXML(bytes []byte) (*EventXML, error) {
+	var eventXML *EventXML
 	if err := xml.Unmarshal(bytes, &eventXML); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
 	}
 	eventXML.Original = string(bytes)
-	return &eventXML, nil
+	return eventXML, nil
 }


### PR DESCRIPTION
This merge release contains following items.

- ITOM-89342 - Duplicate windows events if we use start_at: beginning and restart opsramp-agent
- ITOM-103949 - Exporting user name as default for Security Windows Event, 
- ITOM-106703 - Improve the agent to handle more load based on configs
- ITOM-106204 - Refactored the hard coded settings into configurable (read write buffer, grpc send/ recv buffer size, processor batch configuration, receiver initial buffer memory), when values not set, defaulted to org settings

