### PR TITLE
Fix: ITOM-113919 - Attach service metrics to namespace resourcetype instead of defaulting to cluster

### DIFF
--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -388,7 +388,7 @@ func withAddOnFields(filters ...AddOnMetadata) option {
 		var fields []kube.AddOnMetadata
 		for _, f := range filters {
 
-			fmt.Println("The value of key : ", f.Key, " Value : ", f.Value)
+			// fmt.Println("The value of key : ", f.Key, " Value : ", f.Value)
 
 			fields = append(fields, kube.AddOnMetadata{
 				Key:   f.Key,
@@ -401,7 +401,7 @@ func withAddOnFields(filters ...AddOnMetadata) option {
 }
 
 func withRedisConfigFields(filters redis.OpsrampRedisConfig) option {
-	fmt.Println("The value of filters received  : ", filters)
+	// fmt.Println("The value of filters received  : ", filters)
 
 	return func(p *kubernetesprocessor) error {
 		p.redisConfig = filters

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -320,6 +320,13 @@ func (kp *kubernetesprocessor) processopsrampResources(ctx context.Context, reso
 			kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("daemonset", dsname.Str()))
 		}
 		resourceType = "daemonset"
+	} else if nsname, found := resource.Attributes().Get("k8s.namespace.name"); found {
+		if _, found := resource.Attributes().Get("opsramp.sd.role"); found {
+			if resourceUuid = kp.GetResourceUuidUsingNamespaceMoid(ctx, resource); resourceUuid == "" {
+				kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("namespacename", nsname.Str()))
+			}
+			resourceType = "namespace"
+		}
 	} else {
 		if resourceUuid = kp.redisConfig.ClusterUid; resourceUuid == "" {
 			kp.logger.Debug("opsramp resourceuuid not found", zap.Any("clustername", kp.redisConfig.ClusterName))
@@ -539,6 +546,22 @@ func (op *kubernetesprocessor) GetResourceUuidUsingCurrentNodeMoid(ctx context.C
 
 	resourceUuid = op.redisClient.GetUuidValueInString(ctx, nodeMoidKey)
 	op.logger.Debug("redis KV ", zap.Any("key", nodeMoidKey), zap.Any("value", resourceUuid))
+	return
+}
+
+func (op *kubernetesprocessor) GetResourceUuidUsingNamespaceMoid(ctx context.Context, resource pcommon.Resource) (resourceUuid string) {
+	var namespace pcommon.Value
+	var found bool
+
+	if namespace, found = resource.Attributes().Get("k8s.namespace.name"); !found {
+		op.logger.Debug("k8s.namespace.name not found in resource attributes hence not able to get resource uuid using namespace moid")
+		return
+	}
+
+	namespaceMoidKey := moid.NewMoid(op.redisConfig.ClusterName).WithNamespaceName(namespace.Str()).NamespaceMoid()
+
+	resourceUuid = op.redisClient.GetUuidValueInString(ctx, namespaceMoidKey)
+	op.logger.Debug("redis KV ", zap.Any("key", namespaceMoidKey), zap.Any("value", resourceUuid))
 	return
 }
 

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -321,7 +321,7 @@ func (kp *kubernetesprocessor) processopsrampResources(ctx context.Context, reso
 		}
 		resourceType = "daemonset"
 	} else if nsname, found := resource.Attributes().Get("k8s.namespace.name"); found {
-		if _, found := resource.Attributes().Get("opsramp.sd.role"); found {
+		if _, found := resource.Attributes().Get("prometheus.sd.role"); found {
 			if resourceUuid = kp.GetResourceUuidUsingNamespaceMoid(ctx, resource); resourceUuid == "" {
 				kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("namespacename", nsname.Str()))
 			}

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -290,7 +290,10 @@ func (kp *kubernetesprocessor) processopsrampResources(ctx context.Context, reso
 	}
 	var resourceType string
 
-	if podname, found := resource.Attributes().Get("k8s.pod.name"); found {
+	if _, found := resource.Attributes().Get("map.to.namespace"); found {
+		resourceUuid = kp.GetResourceUuidUsingNamespaceMoid(ctx, resource)
+		resourceType = "namespace"
+	} else if podname, found := resource.Attributes().Get("k8s.pod.name"); found {
 		if resourceUuid = kp.GetResourceUuidUsingPodMoid(ctx, resource); resourceUuid == "" {
 			kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("podname", podname.Str()))
 		}
@@ -320,13 +323,6 @@ func (kp *kubernetesprocessor) processopsrampResources(ctx context.Context, reso
 			kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("daemonset", dsname.Str()))
 		}
 		resourceType = "daemonset"
-	} else if nsname, found := resource.Attributes().Get("k8s.namespace.name"); found {
-		if _, found := resource.Attributes().Get("prometheus.sd.role"); found {
-			if resourceUuid = kp.GetResourceUuidUsingNamespaceMoid(ctx, resource); resourceUuid == "" {
-				kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("namespacename", nsname.Str()))
-			}
-			resourceType = "namespace"
-		}
 	} else {
 		if resourceUuid = kp.redisConfig.ClusterUid; resourceUuid == "" {
 			kp.logger.Debug("opsramp resourceuuid not found", zap.Any("clustername", kp.redisConfig.ClusterName))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>
https://hpe.atlassian.net/browse/ITOM-113919

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>