### PR TITLE
Fix: Attach service metrics to namespace resourcetype instead of defaulting to cluster

### DIFF
--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -431,7 +431,7 @@ func withAddOnFields(filters ...AddOnMetadata) option {
 		var fields []kube.AddOnMetadata
 		for _, f := range filters {
 
-			fmt.Println("The value of key : ", f.Key, " Value : ", f.Value)
+			// fmt.Println("The value of key : ", f.Key, " Value : ", f.Value)
 
 			fields = append(fields, kube.AddOnMetadata{
 				Key:   f.Key,
@@ -444,7 +444,7 @@ func withAddOnFields(filters ...AddOnMetadata) option {
 }
 
 func withRedisConfigFields(filters redis.OpsrampRedisConfig) option {
-	fmt.Println("The value of filters received  : ", filters)
+	// fmt.Println("The value of filters received  : ", filters)
 
 	return func(p *kubernetesprocessor) error {
 		p.redisConfig = filters

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -635,7 +635,10 @@ func (kp *kubernetesprocessor) processopsrampResources(ctx context.Context, reso
 	}
 	var resourceType string
 
-	if podname, found := resource.Attributes().Get("k8s.pod.name"); found {
+	if _, found := resource.Attributes().Get("map.to.namespace"); found {
+		resourceUuid = kp.GetResourceUuidUsingNamespaceMoid(ctx, resource)
+		resourceType = "namespace"
+	} else if podname, found := resource.Attributes().Get("k8s.pod.name"); found {
 		if resourceUuid = kp.GetResourceUuidUsingPodMoid(ctx, resource); resourceUuid == "" {
 			kp.logger.Debug("opsramp resourceuuid not found in redis", zap.Any("podname", podname.Str()))
 		}
@@ -865,6 +868,22 @@ func (op *kubernetesprocessor) GetResourceUuidUsingCurrentNodeMoid(ctx context.C
 
 	resourceUuid = op.redisClient.GetUuidValueInString(ctx, nodeMoidKey)
 	op.logger.Debug("redis KV ", zap.Any("key", nodeMoidKey), zap.Any("value", resourceUuid))
+	return
+}
+
+func (op *kubernetesprocessor) GetResourceUuidUsingNamespaceMoid(ctx context.Context, resource pcommon.Resource) (resourceUuid string) {
+	var namespace pcommon.Value
+	var found bool
+
+	if namespace, found = resource.Attributes().Get("k8s.namespace.name"); !found {
+		op.logger.Debug("k8s.namespace.name not found in resource attributes hence not able to get resource uuid using namespace moid")
+		return
+	}
+
+	namespaceMoidKey := moid.NewMoid(op.redisConfig.ClusterName).WithNamespaceName(namespace.Str()).NamespaceMoid()
+
+	resourceUuid = op.redisClient.GetUuidValueInString(ctx, namespaceMoidKey)
+	op.logger.Debug("redis KV ", zap.Any("key", namespaceMoidKey), zap.Any("value", resourceUuid))
 	return
 }
 


### PR DESCRIPTION

* attach service metrics to namespace resourcetype

* renamed attribute name

* removed unnecessary log which prints redis details

* rename resource attribute name and condition logic refactored

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>