### PR TITLE
feat(k8seventsreceiver): add exclude_reasons filter to InvolvedObject…

### DIFF
--- a/receiver/k8seventsreceiver/config.go
+++ b/receiver/k8seventsreceiver/config.go
@@ -47,6 +47,10 @@ type Config struct {
 type InvolvedObjectProperties struct {
 	// Include only the specified reasons. If its empty, list events of all reasons.
 	IncludeReasons []ReasonProperties `mapstructure:"include_reasons,omitempty"`
+	// Exclude events with the specified reasons. Takes precedence over include_reasons.
+	// If empty or absent, no events are excluded.
+	// Note: Only the Name field of each entry is used for matching; Attributes are ignored.
+	ExcludeReasons []ReasonProperties `mapstructure:"exclude_reasons,omitempty"`
 
 	//Can be enhanced to take in object names with reg ex etc.
 }

--- a/receiver/k8seventsreceiver/config_test.go
+++ b/receiver/k8seventsreceiver/config_test.go
@@ -42,6 +42,24 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "exclude_reasons"),
+			expected: &Config{
+				Namespaces: []string{"default"},
+				IncludeInvolvedObject: map[string]InvolvedObjectProperties{
+					"Pod": {
+						IncludeReasons: []ReasonProperties{{Name: "Failed"}},
+						ExcludeReasons: []ReasonProperties{{Name: "SomeNoisyReason"}},
+					},
+					"Node": {
+						ExcludeReasons: []ReasonProperties{{Name: "NodeHasSufficientDisk"}},
+					},
+				},
+				APIConfig: k8sconfig.APIConfig{
+					AuthType: k8sconfig.AuthTypeServiceAccount,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/k8seventsreceiver/receiver.go
+++ b/receiver/k8seventsreceiver/receiver.go
@@ -28,9 +28,10 @@ import (
 )
 
 type k8seventsReceiver struct {
-	config          *Config
-	excludedNSSet   map[string]struct{} // built from config.ExcludeNamespaces at startup; nil when no exclusions
-	settings        receiver.Settings
+	config             *Config
+	excludedNSSet      map[string]struct{}            // built from config.ExcludeNamespaces at startup; nil when no exclusions
+	excludedReasonsSet map[string]map[string]struct{} // kind → excluded reason names; nil when no exclusions
+	settings           receiver.Settings
 	logsConsumer    consumer.Logs
 	stopperChanList []chan struct{}
 	startTime       time.Time
@@ -64,13 +65,24 @@ func newReceiver(
 		excludedNSSet = toSet(config.ExcludeNamespaces)
 	}
 
+	var excludedReasonsSet map[string]map[string]struct{}
+	for kind, prop := range config.IncludeInvolvedObject {
+		if len(prop.ExcludeReasons) > 0 {
+			if excludedReasonsSet == nil {
+				excludedReasonsSet = make(map[string]map[string]struct{})
+			}
+			excludedReasonsSet[kind] = toReasonNameSet(prop.ExcludeReasons)
+		}
+	}
+
 	return &k8seventsReceiver{
-		settings:      set,
-		config:        config,
-		excludedNSSet: excludedNSSet,
-		logsConsumer:  consumer,
-		startTime:     time.Now(),
-		obsrecv:       obsrecv,
+		settings:           set,
+		config:             config,
+		excludedNSSet:      excludedNSSet,
+		excludedReasonsSet: excludedReasonsSet,
+		logsConsumer:       consumer,
+		startTime:          time.Now(),
+		obsrecv:            obsrecv,
 	}, nil
 }
 
@@ -144,6 +156,17 @@ func toSet(items []string) map[string]struct{} {
 	s := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		s[item] = struct{}{}
+	}
+	return s
+}
+
+// toReasonNameSet builds an O(1) lookup set from a slice of ReasonProperties.
+// Only the Name field is used; Attributes are ignored.
+// Used for building exclude_reasons filter sets at startup.
+func toReasonNameSet(reasons []ReasonProperties) map[string]struct{} {
+	s := make(map[string]struct{}, len(reasons))
+	for _, r := range reasons {
+		s[r.Name] = struct{}{}
 	}
 	return s
 }
@@ -288,26 +311,29 @@ func (kr *k8seventsReceiver) allowEvent(ev *corev1.Event) (attributes []KeyValue
 	}
 
 	if len(kr.config.IncludeInvolvedObject) != 0 {
-		if prop, exists := kr.config.IncludeInvolvedObject[ev.InvolvedObject.Kind]; !exists {
-			if prop, exists := kr.config.IncludeInvolvedObject["Other"]; !exists {
+		resolvedKind := ev.InvolvedObject.Kind
+		prop, exists := kr.config.IncludeInvolvedObject[resolvedKind]
+		if !exists {
+			resolvedKind = "Other"
+			prop, exists = kr.config.IncludeInvolvedObject["Other"]
+		}
+		if !exists {
+			return attributes, false
+		}
+
+		if len(prop.IncludeReasons) != 0 {
+			if reasonAttributes, exists := existsInSlice(ev.Reason, prop.IncludeReasons); !exists {
 				return attributes, false
 			} else {
-				if len(prop.IncludeReasons) != 0 {
-					if reasonAttributes, exists := existsInSlice(ev.Reason, prop.IncludeReasons); !exists {
-						return attributes, false
-					} else {
-						attributes = reasonAttributes
-					}
-				}
+				attributes = reasonAttributes
 			}
-		} else {
-			if len(prop.IncludeReasons) != 0 {
-				if reasonAttributes, exists := existsInSlice(ev.Reason, prop.IncludeReasons); !exists {
-					return attributes, false
-				} else {
-					attributes = reasonAttributes
-				}
-			}
+		}
+
+		// ExcludeReasons gate: drop event if reason is in exclude set for the resolved kind.
+		// Exclude takes precedence over include (checked after include passes).
+		// excludedReasonsSet is built once in newReceiver(); nil map lookup is safe in Go.
+		if _, excluded := kr.excludedReasonsSet[resolvedKind][ev.Reason]; excluded {
+			return attributes, false
 		}
 	}
 

--- a/receiver/k8seventsreceiver/receiver_test.go
+++ b/receiver/k8seventsreceiver/receiver_test.go
@@ -491,3 +491,111 @@ func TestAllowEventExcludeNamespaces(t *testing.T) {
 	}
 }
 
+// TestAllowEventExcludeReasons validates exclude_reasons filtering in allowEvent().
+func TestAllowEventExcludeReasons(t *testing.T) {
+	makeRecv := func(cfg map[string]InvolvedObjectProperties) *k8seventsReceiver {
+		rCfg := createDefaultConfig().(*Config)
+		rCfg.IncludeInvolvedObject = cfg
+		rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {
+			return fake.NewClientset(), nil
+		}
+		scheme := runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
+		rCfg.makeDynamicClient = func(k8sconfig.APIConfig) (dynamic.Interface, error) {
+			return dynamicfake.NewSimpleDynamicClient(scheme), nil
+		}
+		r, err := newReceiver(receivertest.NewNopSettings(metadata.Type), rCfg, consumertest.NewNop())
+		require.NoError(t, err)
+		recv := r.(*k8seventsReceiver)
+		recv.startTime = time.Time{} // allow all timestamps
+		return recv
+	}
+
+	makeEvent := func(kind, reason string) *corev1.Event {
+		ev := getEvent("Normal")
+		ev.InvolvedObject.Kind = kind
+		ev.Reason = reason
+		return ev
+	}
+
+	tests := []struct {
+		name   string
+		cfg    map[string]InvolvedObjectProperties
+		ev     *corev1.Event
+		wantOK bool
+	}{
+		// T1.3a: reason in exclude_reasons → dropped
+		{
+			name: "T1.3a exclude drops event",
+			cfg: map[string]InvolvedObjectProperties{
+				"Pod": {ExcludeReasons: []ReasonProperties{{Name: "SomeNoisyReason"}}},
+			},
+			ev:     makeEvent("Pod", "SomeNoisyReason"),
+			wantOK: false,
+		},
+		// T1.3b: exclude_reasons absent → allowed
+		{
+			name: "T1.3b absent exclude allows event",
+			cfg: map[string]InvolvedObjectProperties{
+				"Pod": {},
+			},
+			ev:     makeEvent("Pod", "AnyReason"),
+			wantOK: true,
+		},
+		// T1.3c: same reason in include+exclude → exclude wins
+		{
+			name: "T1.3c include+exclude overlap: exclude wins",
+			cfg: map[string]InvolvedObjectProperties{
+				"Pod": {
+					IncludeReasons: []ReasonProperties{{Name: "SharedReason"}},
+					ExcludeReasons: []ReasonProperties{{Name: "SharedReason"}},
+				},
+			},
+			ev:     makeEvent("Pod", "SharedReason"),
+			wantOK: false,
+		},
+		// T1.3d: Other fallback exclusion applies to unmatched kind
+		{
+			name: "T1.3d Other fallback: excluded reason dropped",
+			cfg: map[string]InvolvedObjectProperties{
+				"Other": {ExcludeReasons: []ReasonProperties{{Name: "CRDNoise"}}},
+			},
+			ev:     makeEvent("StatefulSet", "CRDNoise"),
+			wantOK: false,
+		},
+		{
+			name: "T1.3d Other fallback: non-excluded reason passes",
+			cfg: map[string]InvolvedObjectProperties{
+				"Other": {ExcludeReasons: []ReasonProperties{{Name: "CRDNoise"}}},
+			},
+			ev:     makeEvent("StatefulSet", "SomeOtherReason"),
+			wantOK: true,
+		},
+		// T1.3e: exclude without include → collect all except excluded
+		{
+			name: "T1.3e exclude-only: excluded reason dropped",
+			cfg: map[string]InvolvedObjectProperties{
+				"Node": {ExcludeReasons: []ReasonProperties{{Name: "NodeHasSufficientDisk"}}},
+			},
+			ev:     makeEvent("Node", "NodeHasSufficientDisk"),
+			wantOK: false,
+		},
+		{
+			name: "T1.3e exclude-only: non-excluded reason allowed",
+			cfg: map[string]InvolvedObjectProperties{
+				"Node": {ExcludeReasons: []ReasonProperties{{Name: "NodeHasSufficientDisk"}}},
+			},
+			ev:     makeEvent("Node", "NodeNotReady"),
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recv := makeRecv(tt.cfg)
+			_, got := recv.allowEvent(tt.ev)
+			assert.Equal(t, tt.wantOK, got)
+		})
+	}
+}
+

--- a/receiver/k8seventsreceiver/testdata/config.yaml
+++ b/receiver/k8seventsreceiver/testdata/config.yaml
@@ -2,3 +2,14 @@ k8s_events:
 k8s_events/all_settings:
   namespaces: [ default, my_namespace ]
   exclude_namespaces: [ kube-system ]
+k8s_events/exclude_reasons:
+  namespaces: [ default ]
+  include_involved_objects:
+    Pod:
+      include_reasons:
+        - name: Failed
+      exclude_reasons:
+        - name: SomeNoisyReason
+    Node:
+      exclude_reasons:
+        - name: NodeHasSufficientDisk


### PR DESCRIPTION
…Properties

Adds optional exclude_reasons field to InvolvedObjectProperties struct, enabling operators to suppress known-noisy events by reason name without maintaining a full include allowlist.

Key changes:
- config.go: ExcludeReasons []ReasonProperties field with omitempty
- receiver.go: toReasonNameSet() helper; excludedReasonsSet precomputed in newReceiver(); resolvedKind refactor in allowEvent() + exclude gate
- testdata/config.yaml: k8s_events/exclude_reasons fixture
- config_test.go: TestLoadConfig case for exclude_reasons config
- receiver_test.go: TestAllowEventExcludeReasons (7 sub-tests T1.3a-e)

Semantics: exclude wins over include on overlap; Other fallback exclusion applies to unmatched kinds; nil map lookup safe; backward compatible.

Assisted-by: Claude Sonnet 4.6

Refs: ITOM-116881

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>