### PR TITLE
fix:ITOM-115044:opsrampmetricsfilterprocessor changes for vm and k8s …

### DIFF
--- a/processor/opsrampmetricsfilterprocessor/config.go
+++ b/processor/opsrampmetricsfilterprocessor/config.go
@@ -4,7 +4,10 @@
 package opsrampmetricsfilterprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/opsrampmetricsfilterprocessor"
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -23,25 +26,77 @@ type Config struct {
 	// This is automatically populated from the NAMESPACE environment variable
 	// Users should not set this field directly
 	Namespace string `mapstructure:"namespace"`
+
+	// AlertDefinitionsFilePath is the file path containing alert definitions
+	// Optional: if provided, this takes precedence over ConfigMap
+	AlertDefinitionsFilePath string `mapstructure:"alert_definitions_file_path"`
+
+	// WatchFileChanges enables file watching for dynamic updates
+	// Optional: defaults to true when using file path
+	WatchFileChanges bool `mapstructure:"watch_file_changes"`
+
+	// FileWatchInterval is the interval for checking file changes
+	// Optional: defaults to 30 seconds
+	FileWatchInterval string `mapstructure:"file_watch_interval"`
 }
 
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the processor configuration is valid
 func (cfg *Config) Validate() error {
-	// Set defaults if not provided
-	if cfg.AlertConfigMapName == "" {
-		cfg.AlertConfigMapName = "opsramp-alert-user-config"
+	// Check if both file path and ConfigMap are configured
+	if cfg.AlertDefinitionsFilePath != "" && (cfg.AlertConfigMapName != "" && cfg.AlertConfigMapKey != "") {
+		return fmt.Errorf("cannot specify both alert_definitions_file_path and ConfigMap configuration (alert_definitions_configmap_name/alert_definitions_key)")
 	}
 
-	if cfg.AlertConfigMapKey == "" {
-		cfg.AlertConfigMapKey = "alert-definitions.yaml"
-	}
+	// If file path is provided, validate it
+	if cfg.AlertDefinitionsFilePath != "" {
+		// Validate file path format
+		if !filepath.IsAbs(cfg.AlertDefinitionsFilePath) {
+			return fmt.Errorf("alert_definitions_file_path must be an absolute path: %s", cfg.AlertDefinitionsFilePath)
+		}
 
-	// Set namespace from environment variable if not already set
-	cfg.Namespace = os.Getenv("NAMESPACE")
-	if cfg.Namespace == "" {
-		cfg.Namespace = "opsramp-agent"
+		// Validate file extension
+		ext := filepath.Ext(cfg.AlertDefinitionsFilePath)
+		if ext != ".yaml" && ext != ".yml" {
+			return fmt.Errorf("alert definitions file must have .yaml or .yml extension: %s", cfg.AlertDefinitionsFilePath)
+		}
+
+		// Check if file exists and is readable
+		if _, err := os.Stat(cfg.AlertDefinitionsFilePath); os.IsNotExist(err) {
+			return fmt.Errorf("alert definitions file does not exist: %s", cfg.AlertDefinitionsFilePath)
+		}
+
+		// Validate and set default watch interval
+		if cfg.FileWatchInterval == "" {
+			cfg.FileWatchInterval = "30s"
+		} else {
+			// Validate watch interval format
+			if _, err := time.ParseDuration(cfg.FileWatchInterval); err != nil {
+				return fmt.Errorf("invalid file_watch_interval format: %s (must be valid duration like '30s', '1m')", cfg.FileWatchInterval)
+			}
+		}
+
+		// Default to watching file changes if file path is provided
+		if !cfg.WatchFileChanges {
+			cfg.WatchFileChanges = true
+		}
+	} else {
+
+		// ConfigMap mode - set defaults
+		if cfg.AlertConfigMapName == "" {
+			cfg.AlertConfigMapName = "opsramp-alert-user-config"
+		}
+
+		if cfg.AlertConfigMapKey == "" {
+			cfg.AlertConfigMapKey = "alert-definitions.yaml"
+		}
+
+		// Set namespace from environment variable if not already set
+		cfg.Namespace = os.Getenv("NAMESPACE")
+		if cfg.Namespace == "" {
+			cfg.Namespace = "opsramp-agent"
+		}
 	}
 
 	return nil

--- a/processor/opsrampmetricsfilterprocessor/config.go
+++ b/processor/opsrampmetricsfilterprocessor/config.go
@@ -44,13 +44,13 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the processor configuration is valid
 func (cfg *Config) Validate() error {
-	// Check if both file path and ConfigMap are configured
-	if cfg.AlertDefinitionsFilePath != "" && (cfg.AlertConfigMapName != "" && cfg.AlertConfigMapKey != "") {
-		return fmt.Errorf("cannot specify both alert_definitions_file_path and ConfigMap configuration (alert_definitions_configmap_name/alert_definitions_key)")
-	}
-
-	// If file path is provided, validate it
+	// If file path is provided, it takes precedence. Clear any ConfigMap fields
+	// that may have been populated by createDefaultConfig() to avoid false conflicts.
 	if cfg.AlertDefinitionsFilePath != "" {
+		cfg.AlertConfigMapName = ""
+		cfg.AlertConfigMapKey = ""
+		cfg.Namespace = ""
+
 		// Validate file path format
 		if !filepath.IsAbs(cfg.AlertDefinitionsFilePath) {
 			return fmt.Errorf("alert_definitions_file_path must be an absolute path: %s", cfg.AlertDefinitionsFilePath)
@@ -70,32 +70,23 @@ func (cfg *Config) Validate() error {
 		// Validate and set default watch interval
 		if cfg.FileWatchInterval == "" {
 			cfg.FileWatchInterval = "30s"
-		} else {
-			// Validate watch interval format
-			if _, err := time.ParseDuration(cfg.FileWatchInterval); err != nil {
-				return fmt.Errorf("invalid file_watch_interval format: %s (must be valid duration like '30s', '1m')", cfg.FileWatchInterval)
-			}
-		}
-
-		// Default to watching file changes if file path is provided
-		if !cfg.WatchFileChanges {
-			cfg.WatchFileChanges = true
+		} else if _, err := time.ParseDuration(cfg.FileWatchInterval); err != nil {
+			return fmt.Errorf("invalid file_watch_interval format: %s (must be valid duration like '30s', '1m')", cfg.FileWatchInterval)
 		}
 	} else {
-
-		// ConfigMap mode - set defaults
+		// ConfigMap mode — apply defaults for name/key if unset,
+		// then resolve namespace from env.
 		if cfg.AlertConfigMapName == "" {
 			cfg.AlertConfigMapName = "opsramp-alert-user-config"
 		}
-
 		if cfg.AlertConfigMapKey == "" {
 			cfg.AlertConfigMapKey = "alert-definitions.yaml"
 		}
-
-		// Set namespace from environment variable if not already set
-		cfg.Namespace = os.Getenv("NAMESPACE")
 		if cfg.Namespace == "" {
-			cfg.Namespace = "opsramp-agent"
+			cfg.Namespace = os.Getenv("NAMESPACE")
+			if cfg.Namespace == "" {
+				cfg.Namespace = "opsramp-agent"
+			}
 		}
 	}
 

--- a/processor/opsrampmetricsfilterprocessor/factory.go
+++ b/processor/opsrampmetricsfilterprocessor/factory.go
@@ -29,8 +29,8 @@ func NewFactory() processor.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		AlertConfigMapName: "",
-		AlertConfigMapKey:  "",
+		AlertConfigMapName: "opsramp-alert-user-config",
+		AlertConfigMapKey:  "alert-definitions.yaml",
 		Namespace:          "",
 		WatchFileChanges:   true,
 		FileWatchInterval:  "30s",

--- a/processor/opsrampmetricsfilterprocessor/factory.go
+++ b/processor/opsrampmetricsfilterprocessor/factory.go
@@ -29,9 +29,11 @@ func NewFactory() processor.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		AlertConfigMapName: "opsramp-alert-user-config",
-		AlertConfigMapKey:  "alert-definitions.yaml",
-		Namespace:          "opsramp-agent",
+		AlertConfigMapName: "",
+		AlertConfigMapKey:  "",
+		Namespace:          "",
+		WatchFileChanges:   true,
+		FileWatchInterval:  "30s",
 	}
 }
 

--- a/processor/opsrampmetricsfilterprocessor/go.mod
+++ b/processor/opsrampmetricsfilterprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/opsra
 go 1.25.0
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/prometheus/prometheus v0.311.4-0.20260507094802-91c184a899b8
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.58.0

--- a/processor/opsrampmetricsfilterprocessor/go.sum
+++ b/processor/opsrampmetricsfilterprocessor/go.sum
@@ -62,6 +62,8 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/processor/opsrampmetricsfilterprocessor/processor.go
+++ b/processor/opsrampmetricsfilterprocessor/processor.go
@@ -64,14 +64,11 @@ type filterProcessor struct {
 
 	// File watching
 	fileWatcher      *FileWatcher
-	lastModTime      time.Time
 	watchIntervalDur time.Duration
 
 	// Performance tracking
-	reloadCount      int64
-	lastReloadTime   time.Time
-	processedMetrics int64
-	filteredMetrics  int64
+	reloadCount    int64
+	lastReloadTime time.Time
 
 	// Context for cancellation
 	ctx    context.Context
@@ -134,7 +131,13 @@ func newFilterProcessor(settings processor.Settings, config *Config, nextConsume
 	// Start watching for changes
 	if config.AlertDefinitionsFilePath != "" {
 		if config.WatchFileChanges {
-			go fp.watchFile()
+			watcher, err := fp.createFileWatcher()
+			if err != nil {
+				fp.logger.Error("Failed to create file watcher", zap.Error(err))
+			} else {
+				fp.fileWatcher = watcher
+				go fp.watchFile()
+			}
 		}
 	} else {
 		go fp.watchConfigMap()
@@ -289,18 +292,16 @@ func (fp *filterProcessor) loadAlertDefinitions() error {
 
 // loadAlertDefinitionsFromFile loads alert definitions from a file
 func (fp *filterProcessor) loadAlertDefinitionsFromFile() error {
-	fp.logger.Error("Loading alert definitions from file",
+	fp.logger.Info("Loading alert definitions from file",
 		zap.String("file_path", fp.config.AlertDefinitionsFilePath))
 
-	// Get file modification time for change detection
-	fileInfo, err := os.Stat(fp.config.AlertDefinitionsFilePath)
-	if err != nil {
+	// Verify file is accessible before reading
+	if _, err := os.Stat(fp.config.AlertDefinitionsFilePath); err != nil {
 		fp.logger.Error("Failed to get file info",
 			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
 			zap.Error(err))
 		return fmt.Errorf("failed to get file info for %s: %w", fp.config.AlertDefinitionsFilePath, err)
 	}
-	fp.lastModTime = fileInfo.ModTime()
 
 	// Read file content
 	alertDefData, err := os.ReadFile(fp.config.AlertDefinitionsFilePath)
@@ -381,7 +382,7 @@ func (fp *filterProcessor) processAlertDefinitionsData(data []byte) error {
 		return nil
 	}
 
-	fp.logger.Warn("Loaded alert definitions",
+	fp.logger.Info("Loaded alert definitions",
 		zap.Int("alert_definitions_count", len(nestedDefs.AlertDefinitions)))
 
 	// Extract metrics from alert expressions
@@ -406,7 +407,7 @@ func (fp *filterProcessor) processAlertDefinitionsData(data []byte) error {
 
 		for _, metric := range metrics {
 			newMetricsMap[metric] = true
-			fp.logger.Warn("Extracted metric from rule",
+			fp.logger.Debug("Extracted metric from rule",
 				zap.String("metric", metric),
 				zap.String("rule_name", rule.Name),
 				zap.String("expression", rule.Expr))
@@ -423,7 +424,7 @@ func (fp *filterProcessor) processAlertDefinitionsData(data []byte) error {
 
 	processingDuration := time.Since(startTime)
 
-	fp.logger.Warn("Successfully loaded alert definitions",
+	fp.logger.Info("Successfully loaded alert definitions",
 		zap.Int("total_rules", totalRules),
 		zap.Int("invalid_expressions", invalidExpressions),
 		zap.Int("unique_metrics", len(newMetricsMap)),
@@ -436,7 +437,7 @@ func (fp *filterProcessor) processAlertDefinitionsData(data []byte) error {
 		for metric := range newMetricsMap {
 			metricsList = append(metricsList, metric)
 		}
-		fp.logger.Warn("Extracted metrics from alert definitions",
+		fp.logger.Info("Extracted metrics from alert definitions",
 			zap.Strings("metrics", metricsList))
 	}
 
@@ -478,22 +479,15 @@ func (fp *filterProcessor) extractMetricsFromExpression(expr string) []string {
 	return result
 }
 
-// watchFile watches for changes to the alert definitions file
+// watchFile starts the file watcher. The watcher must be created and assigned
+// to fp.fileWatcher before calling this function. Shutdown() owns the Close().
 func (fp *filterProcessor) watchFile() {
-	// Create file watcher
-	watcher, err := fp.createFileWatcher()
-	if err != nil {
-		fp.logger.Error("Failed to create file watcher", zap.Error(err))
-		return
-	}
-	defer watcher.Close()
-
 	fp.logger.Info("Starting enhanced file watcher",
 		zap.String("file_path", fp.config.AlertDefinitionsFilePath),
-		zap.Bool("using_fsnotify", watcher.useFsNotify),
-		zap.Duration("poll_interval", watcher.pollInterval))
+		zap.Bool("using_fsnotify", fp.fileWatcher.useFsNotify),
+		zap.Duration("poll_interval", fp.fileWatcher.pollInterval))
 
-	watcher.Start()
+	fp.fileWatcher.Start()
 }
 
 // createFileWatcher creates a new file watcher with fsnotify support and polling fallback
@@ -547,13 +541,32 @@ func (fw *FileWatcher) Close() error {
 	return nil
 }
 
-// startFsNotifyWatch uses fsnotify for real-time file change detection
+// startFsNotifyWatch uses fsnotify for real-time file change detection.
+// Uses absolute path comparison to avoid false triggers from same-named files,
+// and debounces rapid events (e.g. vim/VS Code multi-event saves).
 func (fw *FileWatcher) startFsNotifyWatch() {
 	fw.logger.Info("Starting fsnotify file watcher", zap.String("file_path", fw.filePath))
+
+	// Pre-resolve the target path for accurate comparison
+	absFilePath, err := filepath.Abs(fw.filePath)
+	if err != nil {
+		absFilePath = fw.filePath
+	}
+
+	const debounceDelay = 200 * time.Millisecond
+	var (
+		debounceTimer *time.Timer
+		debounceMu    sync.Mutex
+	)
 
 	for {
 		select {
 		case <-fw.ctx.Done():
+			debounceMu.Lock()
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceMu.Unlock()
 			return
 		case event, ok := <-fw.watcher.Events:
 			if !ok {
@@ -561,24 +574,39 @@ func (fw *FileWatcher) startFsNotifyWatch() {
 				return
 			}
 
-			// Check if this event is for our target file
-			if filepath.Base(event.Name) == filepath.Base(fw.filePath) {
-				fw.logger.Debug("File event received",
-					zap.String("file", event.Name),
-					zap.String("operation", event.Op.String()))
+			// Use absolute path comparison to avoid false triggers
+			absEventPath, _ := filepath.Abs(event.Name)
+			if absEventPath != absFilePath {
+				continue
+			}
 
-				// Handle file write, create, or rename events
-				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+			fw.logger.Debug("File event received",
+				zap.String("file", event.Name),
+				zap.String("operation", event.Op.String()))
+
+			// Debounce write/create/rename events to avoid redundant rapid reloads
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+				debounceMu.Lock()
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				eventOp := event.Op.String()
+				debounceTimer = time.AfterFunc(debounceDelay, func() {
+					select {
+					case <-fw.ctx.Done():
+						return
+					default:
+					}
 					fw.logger.Info("File modified, reloading",
 						zap.String("file_path", fw.filePath),
-						zap.String("event", event.Op.String()))
-
+						zap.String("event", eventOp))
 					if err := fw.callback(); err != nil {
 						fw.logger.Error("Failed to reload file after change", zap.Error(err))
 					} else {
 						fw.logger.Info("Successfully reloaded file after change")
 					}
-				}
+				})
+				debounceMu.Unlock()
 			}
 		case err, ok := <-fw.watcher.Errors:
 			if !ok {
@@ -633,31 +661,6 @@ func (fw *FileWatcher) startPollingWatch() {
 					fw.logger.Info("Successfully reloaded file after polling change")
 				}
 			}
-		}
-	}
-}
-
-// checkFileChanges checks if the file has been modified and reloads if necessary
-func (fp *filterProcessor) checkFileChanges() {
-	fileInfo, err := os.Stat(fp.config.AlertDefinitionsFilePath)
-	if err != nil {
-		fp.logger.Error("Failed to get file info during watch",
-			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
-			zap.Error(err))
-		return
-	}
-
-	// Check if file has been modified
-	if fileInfo.ModTime().After(fp.lastModTime) {
-		fp.logger.Info("File changed, reloading alert definitions",
-			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
-			zap.Time("old_mod_time", fp.lastModTime),
-			zap.Time("new_mod_time", fileInfo.ModTime()))
-
-		if err := fp.loadAlertDefinitionsFromFile(); err != nil {
-			fp.logger.Error("Failed to reload alert definitions from file", zap.Error(err))
-		} else {
-			fp.logger.Info("Successfully reloaded alert definitions from file")
 		}
 	}
 }

--- a/processor/opsrampmetricsfilterprocessor/processor.go
+++ b/processor/opsrampmetricsfilterprocessor/processor.go
@@ -6,10 +6,13 @@ package opsrampmetricsfilterprocessor // import "github.com/open-telemetry/opent
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/prometheus/prometheus/promql/parser"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -59,9 +62,31 @@ type filterProcessor struct {
 	metricsMutex sync.RWMutex
 	metricsMap   map[string]bool
 
+	// File watching
+	fileWatcher      *FileWatcher
+	lastModTime      time.Time
+	watchIntervalDur time.Duration
+
+	// Performance tracking
+	reloadCount      int64
+	lastReloadTime   time.Time
+	processedMetrics int64
+	filteredMetrics  int64
+
 	// Context for cancellation
 	ctx    context.Context
 	cancel context.CancelFunc
+}
+
+// FileWatcher handles file system watching for alert definitions
+type FileWatcher struct {
+	filePath     string
+	logger       *zap.Logger
+	callback     func() error
+	watcher      *fsnotify.Watcher
+	ctx          context.Context
+	useFsNotify  bool
+	pollInterval time.Duration
 }
 
 // Ensure filterProcessor implements processor.Metrics interface
@@ -69,27 +94,35 @@ var _ processor.Metrics = (*filterProcessor)(nil)
 
 // newFilterProcessor creates a new instance of the filterProcessor
 func newFilterProcessor(settings processor.Settings, config *Config, nextConsumer consumer.Metrics) (*filterProcessor, error) {
-	// Create Kubernetes client
-	k8sConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes config: %w", err)
-	}
-
-	client, err := kubernetes.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	fp := &filterProcessor{
 		config:       config,
 		nextConsumer: nextConsumer,
 		logger:       settings.Logger,
-		client:       client,
 		metricsMap:   make(map[string]bool),
 		ctx:          ctx,
 		cancel:       cancel,
+	}
+
+	// Parse watch interval for file watching
+	if config.AlertDefinitionsFilePath != "" {
+		watchInterval, err := time.ParseDuration(config.FileWatchInterval)
+		if err != nil {
+			return nil, fmt.Errorf("invalid file_watch_interval: %w", err)
+		}
+		fp.watchIntervalDur = watchInterval
+	} else {
+		// Create Kubernetes client for ConfigMap mode
+		k8sConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Kubernetes config: %w", err)
+		}
+		client, err := kubernetes.NewForConfig(k8sConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+		fp.client = client
 	}
 
 	// Initial load of alert definitions
@@ -98,18 +131,31 @@ func newFilterProcessor(settings processor.Settings, config *Config, nextConsume
 		// Don't return error here, just log it and continue
 	}
 
-	// Start watching for ConfigMap changes
-	go fp.watchConfigMap()
+	// Start watching for changes
+	if config.AlertDefinitionsFilePath != "" {
+		if config.WatchFileChanges {
+			go fp.watchFile()
+		}
+	} else {
+		go fp.watchConfigMap()
+	}
 
 	return fp, nil
 }
 
 // Start starts the processor
 func (fp *filterProcessor) Start(ctx context.Context, host component.Host) error {
-	fp.logger.Info("Starting alert metrics extractor processor",
-		zap.String("configmap_name", fp.config.AlertConfigMapName),
-		zap.String("configmap_key", fp.config.AlertConfigMapKey),
-		zap.String("namespace", fp.config.Namespace))
+	if fp.config.AlertDefinitionsFilePath != "" {
+		fp.logger.Info("Starting alert metrics extractor processor with file path",
+			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+			zap.Bool("watch_changes", fp.config.WatchFileChanges),
+			zap.String("watch_interval", fp.config.FileWatchInterval))
+	} else {
+		fp.logger.Info("Starting alert metrics extractor processor with ConfigMap",
+			zap.String("configmap_name", fp.config.AlertConfigMapName),
+			zap.String("configmap_key", fp.config.AlertConfigMapKey),
+			zap.String("namespace", fp.config.Namespace))
+	}
 
 	// Log the current state of the metrics map
 	fp.metricsMutex.RLock()
@@ -125,6 +171,14 @@ func (fp *filterProcessor) Start(ctx context.Context, host component.Host) error
 // Shutdown stops the processor
 func (fp *filterProcessor) Shutdown(ctx context.Context) error {
 	fp.logger.Info("Shutting down alert metrics extractor processor")
+
+	// Close file watcher if it exists
+	if fp.fileWatcher != nil {
+		if err := fp.fileWatcher.Close(); err != nil {
+			fp.logger.Error("Failed to close file watcher", zap.Error(err))
+		}
+	}
+
 	fp.cancel()
 	return nil
 }
@@ -225,8 +279,43 @@ func (fp *filterProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 	return fp.nextConsumer.ConsumeMetrics(ctx, filteredMetrics)
 }
 
-// loadAlertDefinitions loads alert definitions from the ConfigMap
+// loadAlertDefinitions loads alert definitions from either file or ConfigMap
 func (fp *filterProcessor) loadAlertDefinitions() error {
+	if fp.config.AlertDefinitionsFilePath != "" {
+		return fp.loadAlertDefinitionsFromFile()
+	}
+	return fp.loadAlertDefinitionsFromConfigMap()
+}
+
+// loadAlertDefinitionsFromFile loads alert definitions from a file
+func (fp *filterProcessor) loadAlertDefinitionsFromFile() error {
+	fp.logger.Error("Loading alert definitions from file",
+		zap.String("file_path", fp.config.AlertDefinitionsFilePath))
+
+	// Get file modification time for change detection
+	fileInfo, err := os.Stat(fp.config.AlertDefinitionsFilePath)
+	if err != nil {
+		fp.logger.Error("Failed to get file info",
+			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+			zap.Error(err))
+		return fmt.Errorf("failed to get file info for %s: %w", fp.config.AlertDefinitionsFilePath, err)
+	}
+	fp.lastModTime = fileInfo.ModTime()
+
+	// Read file content
+	alertDefData, err := os.ReadFile(fp.config.AlertDefinitionsFilePath)
+	if err != nil {
+		fp.logger.Error("Failed to read alert definitions file",
+			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+			zap.Error(err))
+		return fmt.Errorf("failed to read file %s: %w", fp.config.AlertDefinitionsFilePath, err)
+	}
+
+	return fp.processAlertDefinitionsData(alertDefData)
+}
+
+// loadAlertDefinitionsFromConfigMap loads alert definitions from the ConfigMap
+func (fp *filterProcessor) loadAlertDefinitionsFromConfigMap() error {
 	fp.logger.Info("Loading alert definitions from ConfigMap",
 		zap.String("configmap", fp.config.AlertConfigMapName),
 		zap.String("namespace", fp.config.Namespace),
@@ -253,31 +342,103 @@ func (fp *filterProcessor) loadAlertDefinitions() error {
 		return fmt.Errorf("key %s not found in ConfigMap %s/%s", fp.config.AlertConfigMapKey, fp.config.Namespace, fp.config.AlertConfigMapName)
 	}
 
-	var alertDefs AlertDefinitions
-	if err := yaml.Unmarshal([]byte(alertDefData), &alertDefs); err != nil {
+	return fp.processAlertDefinitionsData([]byte(alertDefData))
+}
+
+// processAlertDefinitionsData processes the alert definitions YAML data
+func (fp *filterProcessor) processAlertDefinitionsData(data []byte) error {
+	startTime := time.Now()
+
+	// Try nested K8s format: alertDefinitions: [{resourceType, rules: [{name, expr}]}]
+	var nestedDefs AlertDefinitions
+	if err := yaml.Unmarshal(data, &nestedDefs); err != nil {
 		fp.logger.Error("Failed to unmarshal alert definitions", zap.Error(err))
 		return fmt.Errorf("failed to unmarshal alert definitions: %w", err)
 	}
 
-	// Extract metrics from alert expressions
-	newMetricsMap := make(map[string]bool)
-	for _, alertDef := range alertDefs.AlertDefinitions {
-		for _, rule := range alertDef.Rules {
-			metrics := fp.extractMetricsFromExpression(rule.Expr)
-			for _, metric := range metrics {
-				newMetricsMap[metric] = true
-			}
+	var rules []AlertRule
+	for _, def := range nestedDefs.AlertDefinitions {
+		if len(def.Rules) > 0 {
+			rules = append(rules, def.Rules...)
 		}
 	}
 
-	// Update the global metrics map
+	// If no rules found via nested format, fall back to flat VM agent format:
+	// alertDefinitions: [{name, expr, ...}]
+	if len(rules) == 0 {
+		var flatDefs struct {
+			AlertDefinitions []AlertRule `yaml:"alertDefinitions"`
+		}
+		if err := yaml.Unmarshal(data, &flatDefs); err != nil {
+			fp.logger.Error("Failed to unmarshal alert definitions", zap.Error(err))
+			return fmt.Errorf("failed to unmarshal alert definitions: %w", err)
+		}
+		rules = flatDefs.AlertDefinitions
+	}
+
+	if len(rules) == 0 {
+		fp.logger.Warn("No alert definitions found in configuration")
+		return nil
+	}
+
+	fp.logger.Warn("Loaded alert definitions",
+		zap.Int("alert_definitions_count", len(nestedDefs.AlertDefinitions)))
+
+	// Extract metrics from alert expressions
+	newMetricsMap := make(map[string]bool)
+	totalRules := len(rules)
+	invalidExpressions := 0
+
+	for _, rule := range rules {
+		if rule.Expr == "" {
+			fp.logger.Warn("Empty expression found in alert rule",
+				zap.String("rule_name", rule.Name))
+			invalidExpressions++
+			continue
+		}
+
+		metrics := fp.extractMetricsFromExpression(rule.Expr)
+		if len(metrics) == 0 {
+			fp.logger.Warn("No metrics extracted from expression",
+				zap.String("expression", rule.Expr),
+				zap.String("rule_name", rule.Name))
+		}
+
+		for _, metric := range metrics {
+			newMetricsMap[metric] = true
+			fp.logger.Warn("Extracted metric from rule",
+				zap.String("metric", metric),
+				zap.String("rule_name", rule.Name),
+				zap.String("expression", rule.Expr))
+		}
+	}
+
+	// Update the global metrics map and tracking
 	fp.metricsMutex.Lock()
+	previousCount := len(fp.metricsMap)
 	fp.metricsMap = newMetricsMap
+	fp.reloadCount++
+	fp.lastReloadTime = time.Now()
 	fp.metricsMutex.Unlock()
 
-	fp.logger.Info("Successfully loaded alert definitions",
-		zap.Int("alert_definitions", len(alertDefs.AlertDefinitions)),
-		zap.Int("unique_metrics", len(newMetricsMap)))
+	processingDuration := time.Since(startTime)
+
+	fp.logger.Warn("Successfully loaded alert definitions",
+		zap.Int("total_rules", totalRules),
+		zap.Int("invalid_expressions", invalidExpressions),
+		zap.Int("unique_metrics", len(newMetricsMap)),
+		zap.Int("previous_metrics_count", previousCount),
+		zap.Int64("reload_count", fp.reloadCount),
+		zap.Duration("processing_duration", processingDuration))
+
+	if len(newMetricsMap) > 0 {
+		var metricsList []string
+		for metric := range newMetricsMap {
+			metricsList = append(metricsList, metric)
+		}
+		fp.logger.Warn("Extracted metrics from alert definitions",
+			zap.Strings("metrics", metricsList))
+	}
 
 	return nil
 }
@@ -300,8 +461,7 @@ func extractMetricNames(node parser.Node, metrics map[string]struct{}) {
 
 // extractMetricsFromExpression extracts metric names from a PromQL expression
 func (fp *filterProcessor) extractMetricsFromExpression(expr string) []string {
-	p := parser.NewParser(parser.Options{})
-	parsedExpr, err := p.ParseExpr(expr)
+	parsedExpr, err := parser.NewParser(parser.Options{}).ParseExpr(expr)
 	if err != nil {
 		fp.logger.Warn("Failed to parse PromQL expression", zap.String("expr", expr), zap.Error(err))
 		return nil
@@ -316,6 +476,190 @@ func (fp *filterProcessor) extractMetricsFromExpression(expr string) []string {
 	}
 
 	return result
+}
+
+// watchFile watches for changes to the alert definitions file
+func (fp *filterProcessor) watchFile() {
+	// Create file watcher
+	watcher, err := fp.createFileWatcher()
+	if err != nil {
+		fp.logger.Error("Failed to create file watcher", zap.Error(err))
+		return
+	}
+	defer watcher.Close()
+
+	fp.logger.Info("Starting enhanced file watcher",
+		zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+		zap.Bool("using_fsnotify", watcher.useFsNotify),
+		zap.Duration("poll_interval", watcher.pollInterval))
+
+	watcher.Start()
+}
+
+// createFileWatcher creates a new file watcher with fsnotify support and polling fallback
+func (fp *filterProcessor) createFileWatcher() (*FileWatcher, error) {
+	fw := &FileWatcher{
+		filePath:     fp.config.AlertDefinitionsFilePath,
+		logger:       fp.logger,
+		callback:     fp.loadAlertDefinitionsFromFile,
+		ctx:          fp.ctx,
+		pollInterval: fp.watchIntervalDur,
+		useFsNotify:  true,
+	}
+
+	// Try to create fsnotify watcher
+	var err error
+	fw.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		fw.logger.Warn("Failed to create fsnotify watcher, falling back to polling",
+			zap.Error(err))
+		fw.useFsNotify = false
+	} else {
+		// Add the file to the watcher
+		// Watch the directory since file might be replaced (common with editors)
+		dir := filepath.Dir(fw.filePath)
+		if err := fw.watcher.Add(dir); err != nil {
+			fw.logger.Warn("Failed to add directory to watcher, falling back to polling",
+				zap.String("directory", dir),
+				zap.Error(err))
+			fw.watcher.Close()
+			fw.useFsNotify = false
+		}
+	}
+
+	return fw, nil
+}
+
+// Start begins watching for file changes
+func (fw *FileWatcher) Start() {
+	if fw.useFsNotify {
+		fw.startFsNotifyWatch()
+	} else {
+		fw.startPollingWatch()
+	}
+}
+
+// Close stops the file watcher and cleans up resources
+func (fw *FileWatcher) Close() error {
+	if fw.watcher != nil {
+		return fw.watcher.Close()
+	}
+	return nil
+}
+
+// startFsNotifyWatch uses fsnotify for real-time file change detection
+func (fw *FileWatcher) startFsNotifyWatch() {
+	fw.logger.Info("Starting fsnotify file watcher", zap.String("file_path", fw.filePath))
+
+	for {
+		select {
+		case <-fw.ctx.Done():
+			return
+		case event, ok := <-fw.watcher.Events:
+			if !ok {
+				fw.logger.Error("File watcher events channel closed")
+				return
+			}
+
+			// Check if this event is for our target file
+			if filepath.Base(event.Name) == filepath.Base(fw.filePath) {
+				fw.logger.Debug("File event received",
+					zap.String("file", event.Name),
+					zap.String("operation", event.Op.String()))
+
+				// Handle file write, create, or rename events
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+					fw.logger.Info("File modified, reloading",
+						zap.String("file_path", fw.filePath),
+						zap.String("event", event.Op.String()))
+
+					if err := fw.callback(); err != nil {
+						fw.logger.Error("Failed to reload file after change", zap.Error(err))
+					} else {
+						fw.logger.Info("Successfully reloaded file after change")
+					}
+				}
+			}
+		case err, ok := <-fw.watcher.Errors:
+			if !ok {
+				fw.logger.Error("File watcher errors channel closed")
+				return
+			}
+			fw.logger.Error("File watcher error", zap.Error(err))
+		}
+	}
+}
+
+// startPollingWatch falls back to polling for file changes
+func (fw *FileWatcher) startPollingWatch() {
+	fw.logger.Info("Starting polling file watcher",
+		zap.String("file_path", fw.filePath),
+		zap.Duration("interval", fw.pollInterval))
+
+	var lastModTime time.Time
+
+	// Get initial modification time
+	if fileInfo, err := os.Stat(fw.filePath); err == nil {
+		lastModTime = fileInfo.ModTime()
+	}
+
+	ticker := time.NewTicker(fw.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-fw.ctx.Done():
+			return
+		case <-ticker.C:
+			fileInfo, err := os.Stat(fw.filePath)
+			if err != nil {
+				fw.logger.Error("Failed to get file info during polling",
+					zap.String("file_path", fw.filePath),
+					zap.Error(err))
+				continue
+			}
+
+			// Check if file has been modified
+			if fileInfo.ModTime().After(lastModTime) {
+				fw.logger.Info("File changed (polling), reloading",
+					zap.String("file_path", fw.filePath),
+					zap.Time("old_mod_time", lastModTime),
+					zap.Time("new_mod_time", fileInfo.ModTime()))
+
+				lastModTime = fileInfo.ModTime()
+				if err := fw.callback(); err != nil {
+					fw.logger.Error("Failed to reload file after polling change", zap.Error(err))
+				} else {
+					fw.logger.Info("Successfully reloaded file after polling change")
+				}
+			}
+		}
+	}
+}
+
+// checkFileChanges checks if the file has been modified and reloads if necessary
+func (fp *filterProcessor) checkFileChanges() {
+	fileInfo, err := os.Stat(fp.config.AlertDefinitionsFilePath)
+	if err != nil {
+		fp.logger.Error("Failed to get file info during watch",
+			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+			zap.Error(err))
+		return
+	}
+
+	// Check if file has been modified
+	if fileInfo.ModTime().After(fp.lastModTime) {
+		fp.logger.Info("File changed, reloading alert definitions",
+			zap.String("file_path", fp.config.AlertDefinitionsFilePath),
+			zap.Time("old_mod_time", fp.lastModTime),
+			zap.Time("new_mod_time", fileInfo.ModTime()))
+
+		if err := fp.loadAlertDefinitionsFromFile(); err != nil {
+			fp.logger.Error("Failed to reload alert definitions from file", zap.Error(err))
+		} else {
+			fp.logger.Info("Successfully reloaded alert definitions from file")
+		}
+	}
 }
 
 // watchConfigMap watches for changes to the ConfigMap
@@ -370,7 +714,7 @@ func (fp *filterProcessor) doWatch() {
 			switch event.Type {
 			case watch.Modified, watch.Added:
 				fp.logger.Info("ConfigMap changed, reloading alert definitions")
-				if err := fp.loadAlertDefinitions(); err != nil {
+				if err := fp.loadAlertDefinitionsFromConfigMap(); err != nil {
 					fp.logger.Error("Failed to reload alert definitions", zap.Error(err))
 				}
 			case watch.Deleted:


### PR DESCRIPTION
Issue: 
Filter processor is failing to filter the metrics after VM agent chanegs,

fix: Removed the erroneous default assignment of AlertDefinitionsFilePath from the ConfigMap mode branch in Validate(). For the VM agent, this path is already injected by [otel-metrics.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) before OTel starts and does not belong in Validate().f