### PR TITLE
Fixes for agent 22 compatibility and enhancements

### DIFF
--- a/exporter/opsrampotlpexporter/otlp.go
+++ b/exporter/opsrampotlpexporter/otlp.go
@@ -81,6 +81,12 @@ type opsrampOTLPExporter struct {
 	accessToken string
 
 	logger *zap.Logger
+
+	// TLS fallback state
+	originalInsecure     bool           // original Insecure setting from config
+	originalSkipVerify   bool           // original InsecureSkipVerify setting
+	tlsFallbackAttempted bool           // whether we've already tried TLS fallback
+	host                 component.Host // saved for reconnection
 }
 
 // Crete new exporter and start it. The exporter will begin connecting, but
@@ -89,6 +95,8 @@ func newExporter(cfg component.Config, set exporter.Settings) (*opsrampOTLPExpor
 	oCfg := cfg.(*Config)
 
 	// Extract TLS options from the gRPC client config
+	// Insecure=true means no TLS (plain connection)
+	// InsecureSkipVerify=true means TLS but skip cert verification
 	tlsOpts := TLSOptions{
 		Insecure:           oCfg.ClientConfig.TLS.Insecure,
 		InsecureSkipVerify: oCfg.ClientConfig.TLS.InsecureSkipVerify,
@@ -241,6 +249,11 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 	// our manual CONNECT implementation below.
 	originalInsecure := e.config.ClientConfig.TLS.Insecure
 	originalSkipVerify := e.config.ClientConfig.TLS.InsecureSkipVerify
+
+	// Store for TLS fallback mechanism
+	e.originalInsecure = originalInsecure
+	e.originalSkipVerify = originalSkipVerify
+	e.host = host
 	e.config.ClientConfig.TLS.Insecure = true
 
 	e.clientConn, err = e.config.ClientConfig.ToClientConn(
@@ -313,7 +326,9 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 				}
 
 				// Resolve proxy URL from environment (HTTPS_PROXY for TLS, HTTP_PROXY for plain).
-				targetURL := &url.URL{Scheme: proxyLookupScheme(e.config.Endpoint, originalInsecure), Host: dialAddr}
+				scheme := proxyLookupScheme(e.config.Endpoint, originalInsecure)
+				targetURL := &url.URL{Scheme: scheme, Host: dialAddr}
+
 				proxyURL, err := httpproxy.FromEnvironment().ProxyFunc()(targetURL)
 				if err != nil {
 					return nil, fmt.Errorf("proxy resolution failed: %w", err)
@@ -324,6 +339,10 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 					})
 				}
 
+				e.settings.Logger.Debug("Using proxy for connection",
+					zap.String("proxy", proxyURL.Host),
+					zap.String("target", dialAddr))
+
 				// Extract original hostname from endpoint for CONNECT request.
 				// gRPC resolves hostnames to IPs before calling dialer, but proxies
 				// often reject CONNECT requests to raw IPs (e.g., Squid).
@@ -331,11 +350,6 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 				if connectTarget == "" {
 					connectTarget = dialAddr // fallback to resolved address
 				}
-
-				e.settings.Logger.Debug("connecting via proxy",
-					zap.String("proxy", proxyURL.Host), zap.String("connect_target", connectTarget),
-					zap.String("dial_addr", dialAddr),
-					zap.Bool("insecure", originalInsecure), zap.Bool("skipVerify", originalSkipVerify))
 
 				// establishProxyTunnel manually issues HTTP CONNECT with Proxy-Authorization.
 				// Using the standard library directly (rather than golang.org/x/net/proxy)
@@ -349,10 +363,6 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 						if attempt > 0 {
 							// Exponential backoff: 1s, 2s, 4s
 							backoff := time.Duration(1<<uint(attempt-1)) * time.Second
-							e.settings.Logger.Debug("retrying proxy CONNECT after transient error",
-								zap.Int("attempt", attempt+1),
-								zap.Duration("backoff", backoff),
-								zap.Error(lastErr))
 							select {
 							case <-ctx.Done():
 								return nil, ctx.Err()
@@ -399,9 +409,7 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 								lastErr = fmt.Errorf("proxy CONNECT rejected (transient): %s", resp.Status)
 								e.settings.Logger.Warn("proxy returned transient error, will retry",
 									zap.Int("status_code", resp.StatusCode),
-									zap.String("status", resp.Status),
-									zap.Int("attempt", attempt+1),
-									zap.Int("max_retries", maxRetries))
+									zap.Int("attempt", attempt+1))
 								continue
 							}
 							// Non-retryable proxy error (4xx, etc.)
@@ -418,9 +426,7 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 					if strings.Contains(err.Error(), "transient") || strings.Contains(err.Error(), "503") ||
 						strings.Contains(err.Error(), "502") || strings.Contains(err.Error(), "504") {
 						e.settings.Logger.Warn("proxy unavailable, falling back to direct connection",
-							zap.String("target", dialAddr),
-							zap.String("proxy", proxyURL.Host),
-							zap.Error(err))
+							zap.String("target", dialAddr))
 						return establishTLSConnection(dialAddr, func() (net.Conn, error) {
 							return (&net.Dialer{}).DialContext(ctx, "tcp", dialAddr)
 						})
@@ -475,41 +481,11 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 	e.metadata = metadata.New(headers)
 	e.metadata.Set("Authorization", fmt.Sprintf("Bearer %s", e.accessToken))
 
-	// AUTH_DIAG: Log metadata keys being sent with gRPC calls
-	var mdKeys []string
-	for k, v := range e.metadata {
-		if k == "authorization" {
-			if len(v) > 0 && len(v[0]) > 15 {
-				mdKeys = append(mdKeys, fmt.Sprintf("%s=len(%d)", k, len(v[0])))
-			} else {
-				mdKeys = append(mdKeys, fmt.Sprintf("%s=EMPTY_OR_SHORT", k))
-			}
-		} else {
-			mdKeys = append(mdKeys, fmt.Sprintf("%s=%v", k, v))
-		}
-	}
-	if e.logger != nil {
-		e.logger.Debug("AUTH_DIAG: exporter start() metadata", zap.Strings("metadata_entries", mdKeys))
-	}
-	e.settings.Logger.Debug("AUTH_DIAG: exporter start() metadata", zap.Strings("metadata_entries", mdKeys))
-	e.settings.Logger.Debug("AUTH_DIAG: exporter endpoints",
-		zap.String("grpc_endpoint", e.config.ClientConfig.Endpoint),
-		zap.String("oauth_url", e.config.Security.OAuthServiceURL),
-		zap.Int("access_token_len", len(e.accessToken)),
-	)
-
 	e.callOptions = []grpc.CallOption{
 		grpc.MaxCallSendMsgSize(e.config.Security.OtelExporterSetting.GrpcMaxSendSize),
 		grpc.MaxCallRecvMsgSize(e.config.Security.OtelExporterSetting.GrpcMaxRecvSize),
 		grpc.WaitForReady(e.config.ClientConfig.WaitForReady),
 	}
-
-	//e.logger.Debug(
-	//	"OTLP Exporter started",
-	//	zap.String("Calloptions", fmt.Sprintf("%v", e.callOptions)),
-	//	zap.Int("Calloptions -> grpc.MaxCallSendMsgSize", e.config.Security.OtelExporterSetting.GrpcMaxSendSize),
-	//	zap.Int("Calloptions -> grpc.MaxCallRecvMsgSize", e.config.Security.OtelExporterSetting.GrpcMaxRecvSize),
-	//)
 
 	return
 }
@@ -521,11 +497,72 @@ func (e *opsrampOTLPExporter) shutdown(context.Context) error {
 	return e.clientConn.Close()
 }
 
+// isTLSMismatchError checks if the error indicates a TLS/plaintext mismatch,
+// which happens when we send plaintext to a TLS server (EOF, transport closing)
+func (e *opsrampOTLPExporter) isTLSMismatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "EOF") ||
+		strings.Contains(errStr, "transport is closing") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "server preface")
+}
+
+// reconnectWithTLS closes the current connection and reconnects with TLS enabled.
+// This is used as a fallback when originalInsecure=true but the server requires TLS.
+func (e *opsrampOTLPExporter) reconnectWithTLS(ctx context.Context) error {
+	e.mut.Lock()
+	defer e.mut.Unlock()
+
+	// Already attempted fallback or TLS was already enabled
+	if e.tlsFallbackAttempted || !e.originalInsecure {
+		return nil
+	}
+
+	e.settings.Logger.Warn("Connection failed with Insecure=true, attempting TLS fallback")
+
+	// Mark fallback attempted
+	e.tlsFallbackAttempted = true
+
+	// Close existing connection
+	if e.clientConn != nil {
+		e.clientConn.Close()
+		e.clientConn = nil
+	}
+
+	// Force TLS for reconnection: Insecure=false, InsecureSkipVerify=true
+	e.config.ClientConfig.TLS.Insecure = false
+	e.config.ClientConfig.TLS.InsecureSkipVerify = true
+	e.originalInsecure = false
+	e.originalSkipVerify = true
+
+	// Reconnect using start()
+	if err := e.start(ctx, e.host); err != nil {
+		e.settings.Logger.Error("TLS fallback reconnection failed", zap.Error(err))
+		return err
+	}
+
+	e.settings.Logger.Info("TLS fallback reconnection successful")
+	return nil
+}
+
 func (e *opsrampOTLPExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
 	req := ptraceotlp.NewExportRequestFromTraces(td)
 	_, err := e.traceExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
 	// trying to get new access token in case of expiration
 	if err != nil {
+		// TLS fallback: if originalInsecure=true and we get TLS mismatch errors, retry with TLS
+		if e.isTLSMismatchError(err) && e.originalInsecure && !e.tlsFallbackAttempted {
+			if reconnErr := e.reconnectWithTLS(ctx); reconnErr == nil {
+				_, err = e.traceExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
+				if err == nil {
+					return nil
+				}
+			}
+		}
+
 		st := status.Convert(err)
 		if st.Code() == codes.Unauthenticated {
 			if err = e.updateExpiredToken(); err != nil {
@@ -546,6 +583,16 @@ func (e *opsrampOTLPExporter) pushMetrics(ctx context.Context, md pmetric.Metric
 	_, err := e.metricExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
 	// trying to get new access token in case of expiration
 	if err != nil {
+		// TLS fallback: if originalInsecure=true and we get TLS mismatch errors, retry with TLS
+		if e.isTLSMismatchError(err) && e.originalInsecure && !e.tlsFallbackAttempted {
+			if reconnErr := e.reconnectWithTLS(ctx); reconnErr == nil {
+				_, err = e.metricExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
+				if err == nil {
+					return nil
+				}
+			}
+		}
+
 		st := status.Convert(err)
 		if st.Code() == codes.Unauthenticated {
 			if err = e.updateExpiredToken(); err != nil {
@@ -568,9 +615,6 @@ func (e *opsrampOTLPExporter) pushLogs(_ context.Context, ld plog.Logs) error {
 		return nil
 	}
 
-	//start := time.Now()
-	//e.logger.Debug("Exporter: pushLogs Started processing logs", zap.String("start at", start.Format(time.RFC3339)))
-
 	if e.config.Masking != nil {
 		e.applyMasking(ld)
 	}
@@ -581,84 +625,31 @@ func (e *opsrampOTLPExporter) pushLogs(_ context.Context, ld plog.Logs) error {
 		return nil
 	}
 
-	if e.config.Masking != nil {
-		e.applyMasking(ld)
-	}
-
-	if e.config.ExpirationSkip != 0 {
-		e.skipExpired(ld)
-	}
-
 	req := plogotlp.NewExportRequestFromLogs(ld)
-	//
-	//data, _ := req.MarshalJSON()
-	//e.logger.Debug("request details",
-	//	zap.String("started_at", start.Format(time.RFC3339Nano)),
-	//	zap.Int("ResourceLogsCount", ld.ResourceLogs().Len()),
-	//	zap.Int("TotalLogRecordCount", ld.LogRecordCount()),
-	//	zap.Int("RequestSizeBytes", len(data)),
-	//)
-	//
-	//beforePushEndTime := time.Now()
 
 	_, err := e.logExporter.Export(e.enhanceContext(context.Background()), req, e.callOptions...)
-
-	//end := time.Now()
-	//e.logger.Debug("Exporter: pushLogs: completed processing logs",
-	//	zap.String("Stage 1", "before push"),
-	//	zap.String("ended_at", beforePushEndTime.Format(time.RFC3339Nano)),
-	//	zap.Float64("duration_seconds", beforePushEndTime.Sub(start).Seconds()),
-	//	zap.Int64("duration_ms", beforePushEndTime.Sub(start).Milliseconds()),
-	//	zap.Float64("duration_seconds", beforePushEndTime.Sub(start).Seconds()),
-	//	zap.String("Stage 1", "before push - end"),
-	//
-	//	zap.String("Stage 2", "after push"),
-	//	zap.String("ended_at", end.Format(time.RFC3339Nano)),
-	//	zap.Float64("duration_seconds", end.Sub(start).Seconds()),
-	//	zap.Int64("duration_ms", end.Sub(start).Milliseconds()),
-	//	zap.Float64("duration_seconds", end.Sub(start).Seconds()),
-	//	zap.String("Stage 2", "after push - end"),
-	//)
 
 	// trying to get a new access token in case of expiration
 	if err != nil {
 		st := status.Convert(err)
-		e.settings.Logger.Warn("AUTH_DIAG: pushLogs Export failed",
-			zap.String("grpc_code", st.Code().String()),
-			zap.String("error", err.Error()),
-			zap.Int("metadata_len", e.metadata.Len()),
-			zap.Bool("has_tenantId", len(e.metadata.Get("tenantid")) > 0),
-			zap.String("tenantId_value", strings.Join(e.metadata.Get("tenantid"), ",")),
-			zap.Bool("has_authorization", len(e.metadata.Get("authorization")) > 0),
-			zap.Int("access_token_len", len(e.accessToken)),
-		)
-		if e.logger != nil {
-			e.logger.Warn("AUTH_DIAG: pushLogs Export failed",
-				zap.String("grpc_code", st.Code().String()),
-				zap.String("error", err.Error()),
-				zap.Int("metadata_len", e.metadata.Len()),
-				zap.Bool("has_tenantId", len(e.metadata.Get("tenantid")) > 0),
-				zap.String("tenantId_value", strings.Join(e.metadata.Get("tenantid"), ",")),
-				zap.Bool("has_authorization", len(e.metadata.Get("authorization")) > 0),
-				zap.Int("access_token_len", len(e.accessToken)),
-			)
+
+		// TLS fallback: if originalInsecure=true and we get TLS mismatch errors, retry with TLS
+		if e.isTLSMismatchError(err) && e.originalInsecure && !e.tlsFallbackAttempted {
+			if reconnErr := e.reconnectWithTLS(context.Background()); reconnErr == nil {
+				_, err = e.logExporter.Export(e.enhanceContext(context.Background()), req, e.callOptions...)
+				if err == nil {
+					return nil
+				}
+			}
 		}
+
 		if st.Code() == codes.Unauthenticated {
 			if err = e.updateExpiredToken(); err != nil {
-				e.settings.Logger.Error("AUTH_DIAG: token refresh failed", zap.Error(err))
 				return fmt.Errorf("couldn't retrieve new token instead of expired: %w", err)
 			}
-			e.settings.Logger.Debug("AUTH_DIAG: token refreshed, retrying Export",
-				zap.Int("new_token_len", len(e.accessToken)),
-			)
 
 			_, err = e.logExporter.Export(e.enhanceContext(context.Background()), req, e.callOptions...)
 			if err != nil {
-				e.settings.Logger.Error("AUTH_DIAG: retry Export also failed after token refresh",
-					zap.Error(err),
-					zap.String("tenantId_value", strings.Join(e.metadata.Get("tenantid"), ",")),
-					zap.Int("access_token_len", len(e.accessToken)),
-				)
 				return err
 			}
 		}
@@ -679,11 +670,6 @@ func (e *opsrampOTLPExporter) updateExpiredToken() error {
 	}
 	e.mut.Lock()
 	defer e.mut.Unlock()
-	e.settings.Logger.Debug("AUTH_DIAG: updateExpiredToken refreshed",
-		zap.Int("old_token_len", len(e.accessToken)),
-		zap.Int("new_token_len", len(accessToken)),
-		zap.Bool("token_changed", e.accessToken != accessToken),
-	)
 	e.accessToken = accessToken
 	// Always update the metadata when token is refreshed
 	e.metadata.Set("Authorization", fmt.Sprintf("Bearer %s", e.accessToken))

--- a/exporter/opsrampotlpexporter/otlp.go
+++ b/exporter/opsrampotlpexporter/otlp.go
@@ -208,17 +208,17 @@ func getAuthToken(cfg SecuritySettings, tlsOpts TLSOptions) (string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		tokenRenewInProgress = false
-		return "", fmt.Errorf("AUTH_DIAG: OAuth token request failed with status=%d body=%s", resp.StatusCode, string(jsonResp))
+		return "", fmt.Errorf("getAuthToken: OAuth token request failed with status=%d body=%s", resp.StatusCode, string(jsonResp))
 	}
 
 	if err := json.Unmarshal(jsonResp, &credentials); err != nil {
 		tokenRenewInProgress = false
-		return "", fmt.Errorf("AUTH_DIAG: failed to unmarshal OAuth response: %w body=%s", err, string(jsonResp))
+		return "", fmt.Errorf("getAuthToken: failed to unmarshal OAuth response: %w body=%s", err, string(jsonResp))
 	}
 
 	if credentials.AccessToken == "" {
 		tokenRenewInProgress = false
-		return "", fmt.Errorf("AUTH_DIAG: OAuth returned empty access_token, response body=%s", string(jsonResp))
+		return "", fmt.Errorf("getAuthToken: OAuth returned empty access_token, response body=%s", string(jsonResp))
 	}
 	tokenRenewInProgress = false
 	return credentials.AccessToken, nil
@@ -324,52 +324,107 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 					})
 				}
 
+				// Extract original hostname from endpoint for CONNECT request.
+				// gRPC resolves hostnames to IPs before calling dialer, but proxies
+				// often reject CONNECT requests to raw IPs (e.g., Squid).
+				connectTarget := endpointHostPort(e.config.Endpoint)
+				if connectTarget == "" {
+					connectTarget = dialAddr // fallback to resolved address
+				}
+
 				e.settings.Logger.Debug("connecting via proxy",
-					zap.String("proxy", proxyURL.Host), zap.String("target", dialAddr),
+					zap.String("proxy", proxyURL.Host), zap.String("connect_target", connectTarget),
+					zap.String("dial_addr", dialAddr),
 					zap.Bool("insecure", originalInsecure), zap.Bool("skipVerify", originalSkipVerify))
 
 				// establishProxyTunnel manually issues HTTP CONNECT with Proxy-Authorization.
 				// Using the standard library directly (rather than golang.org/x/net/proxy)
 				// ensures the Proxy-Authorization header is always sent correctly.
+				// Includes retry logic for transient proxy errors (5xx).
 				establishProxyTunnel := func() (net.Conn, error) {
-					conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", proxyURL.Host)
-					if err != nil {
-						return nil, fmt.Errorf("proxy dial failed: %w", err)
+					const maxRetries = 3
+					var lastErr error
+
+					for attempt := 0; attempt < maxRetries; attempt++ {
+						if attempt > 0 {
+							// Exponential backoff: 1s, 2s, 4s
+							backoff := time.Duration(1<<uint(attempt-1)) * time.Second
+							e.settings.Logger.Debug("retrying proxy CONNECT after transient error",
+								zap.Int("attempt", attempt+1),
+								zap.Duration("backoff", backoff),
+								zap.Error(lastErr))
+							select {
+							case <-ctx.Done():
+								return nil, ctx.Err()
+							case <-time.After(backoff):
+							}
+						}
+
+						conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", proxyURL.Host)
+						if err != nil {
+							lastErr = fmt.Errorf("proxy dial failed: %w", err)
+							continue
+						}
+						connectReq := &http.Request{
+							Method:     "CONNECT",
+							URL:        &url.URL{Opaque: connectTarget},
+							Host:       connectTarget,
+							Header:     make(http.Header),
+							Proto:      "HTTP/1.1",
+							ProtoMajor: 1,
+							ProtoMinor: 1,
+						}
+						if proxyURL.User != nil {
+							username := proxyURL.User.Username()
+							password, _ := proxyURL.User.Password()
+							connectReq.Header.Set("Proxy-Authorization", "Basic "+basicAuth(username, password))
+						}
+						if err := connectReq.Write(conn); err != nil {
+							conn.Close()
+							lastErr = fmt.Errorf("proxy CONNECT write failed: %w", err)
+							continue
+						}
+						br := bufio.NewReader(conn)
+						resp, err := http.ReadResponse(br, connectReq)
+						if err != nil {
+							conn.Close()
+							lastErr = fmt.Errorf("proxy CONNECT read failed: %w", err)
+							continue
+						}
+						resp.Body.Close()
+						if resp.StatusCode != http.StatusOK {
+							conn.Close()
+							// Retry on transient 5xx errors (502, 503, 504)
+							if resp.StatusCode >= 500 && resp.StatusCode < 600 {
+								lastErr = fmt.Errorf("proxy CONNECT rejected (transient): %s", resp.Status)
+								e.settings.Logger.Warn("proxy returned transient error, will retry",
+									zap.Int("status_code", resp.StatusCode),
+									zap.String("status", resp.Status),
+									zap.Int("attempt", attempt+1),
+									zap.Int("max_retries", maxRetries))
+								continue
+							}
+							// Non-retryable proxy error (4xx, etc.)
+							return nil, fmt.Errorf("proxy CONNECT rejected: %s", resp.Status)
+						}
+						return &bufferedConn{Conn: conn, reader: br}, nil
 					}
-					connectReq := &http.Request{
-						Method:     "CONNECT",
-						URL:        &url.URL{Host: dialAddr},
-						Host:       dialAddr,
-						Header:     make(http.Header),
-						Proto:      "HTTP/1.1",
-						ProtoMajor: 1,
-						ProtoMinor: 1,
-					}
-					if proxyURL.User != nil {
-						username := proxyURL.User.Username()
-						password, _ := proxyURL.User.Password()
-						connectReq.Header.Set("Proxy-Authorization", "Basic "+basicAuth(username, password))
-					}
-					if err := connectReq.Write(conn); err != nil {
-						conn.Close()
-						return nil, fmt.Errorf("proxy CONNECT write failed: %w", err)
-					}
-					br := bufio.NewReader(conn)
-					resp, err := http.ReadResponse(br, connectReq)
-					if err != nil {
-						conn.Close()
-						return nil, fmt.Errorf("proxy CONNECT read failed: %w", err)
-					}
-					resp.Body.Close()
-					if resp.StatusCode != http.StatusOK {
-						conn.Close()
-						return nil, fmt.Errorf("proxy CONNECT rejected: %s", resp.Status)
-					}
-					return &bufferedConn{Conn: conn, reader: br}, nil
+					return nil, fmt.Errorf("proxy CONNECT failed after %d retries: %w", maxRetries, lastErr)
 				}
 
 				tunnelConn, err := establishProxyTunnel()
 				if err != nil {
+					// If proxy consistently fails with transient errors, try direct connection as fallback
+					if strings.Contains(err.Error(), "transient") || strings.Contains(err.Error(), "503") ||
+						strings.Contains(err.Error(), "502") || strings.Contains(err.Error(), "504") {
+						e.settings.Logger.Warn("proxy unavailable, falling back to direct connection",
+							zap.String("target", dialAddr),
+							zap.String("proxy", proxyURL.Host),
+							zap.Error(err))
+						return establishTLSConnection(dialAddr, func() (net.Conn, error) {
+							return (&net.Dialer{}).DialContext(ctx, "tcp", dialAddr)
+						})
+					}
 					return nil, err
 				}
 
@@ -856,6 +911,40 @@ func shouldBypassProxy(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// endpointHostPort extracts the host:port from an endpoint string for use in
+// CONNECT requests. This preserves the original hostname (not resolved IP).
+func endpointHostPort(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	// Strip scheme if present (e.g., "https://host:port" -> "host:port")
+	if strings.Contains(endpoint, "://") {
+		u, err := url.Parse(endpoint)
+		if err == nil {
+			host := u.Hostname()
+			port := u.Port()
+			if port == "" {
+				if u.Scheme == "https" {
+					port = "443"
+				} else {
+					port = "80"
+				}
+			}
+			return net.JoinHostPort(host, port)
+		}
+	}
+	// Remove path if present
+	host := endpoint
+	if idx := strings.Index(host, "/"); idx >= 0 {
+		host = host[:idx]
+	}
+	// If no port, add default 443
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		return net.JoinHostPort(host, "443")
+	}
+	return host
 }
 
 func endpointServerName(endpoint string) string {

--- a/exporter/opsrampotlpexporter/otlp.go
+++ b/exporter/opsrampotlpexporter/otlp.go
@@ -15,9 +15,11 @@
 package opsrampotlpexporter // import "go.opentelemetry.io/collector/exporter/otlpexporter"
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,7 +33,6 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/opsramp/go-proxy-dialer/connect" // implemetation for http connect proxy
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -46,7 +47,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http/httpproxy"
-	"golang.org/x/net/proxy"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -88,7 +88,13 @@ type opsrampOTLPExporter struct {
 func newExporter(cfg component.Config, set exporter.Settings) (*opsrampOTLPExporter, error) {
 	oCfg := cfg.(*Config)
 
-	accessToken, err := getAuthToken(oCfg.Security)
+	// Extract TLS options from the gRPC client config
+	tlsOpts := TLSOptions{
+		Insecure:           oCfg.ClientConfig.TLS.Insecure,
+		InsecureSkipVerify: oCfg.ClientConfig.TLS.InsecureSkipVerify,
+	}
+
+	accessToken, err := getAuthToken(oCfg.Security, tlsOpts)
 	if err != nil {
 		tokenRenewInProgress = false
 		return nil, fmt.Errorf("access token isn't available: %w", err)
@@ -118,7 +124,15 @@ type Person struct {
 	Age  int    `json:"age"`
 }
 
-func getAuthToken(cfg SecuritySettings) (string, error) {
+// TLSOptions holds TLS configuration for HTTP/gRPC connections.
+type TLSOptions struct {
+	// Insecure disables TLS entirely (plaintext connection).
+	Insecure bool
+	// InsecureSkipVerify skips server certificate verification.
+	InsecureSkipVerify bool
+}
+
+func getAuthToken(cfg SecuritySettings, tlsOpts TLSOptions) (string, error) {
 	tokenMutex.Lock()
 	defer tokenMutex.Unlock()
 
@@ -132,6 +146,15 @@ func getAuthToken(cfg SecuritySettings) (string, error) {
 		return credentials.AccessToken, nil
 	}
 	tokenRenewInProgress = true
+
+	// Configure TLS based on options
+	var tlsConfig *tls.Config
+	if !tlsOpts.Insecure {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: tlsOpts.InsecureSkipVerify,
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -147,6 +170,7 @@ func getAuthToken(cfg SecuritySettings) (string, error) {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			TLSClientConfig:       tlsConfig,
 		},
 	}
 	data := url.Values{}
@@ -162,10 +186,17 @@ func getAuthToken(cfg SecuritySettings) (string, error) {
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := client.Do(request)
 	if err != nil {
-		if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") || strings.Contains(err.Error(), "TLS handshake timeout") {
-			// If the error is due to an untrusted certificate, we can try to get the token with TLS verification disabled.
+		// Only fallback to TLS disabled mode if InsecureSkipVerify wasn't already true
+		// and the error is TLS-related
+		if !tlsOpts.InsecureSkipVerify &&
+			(strings.Contains(err.Error(), "x509: certificate signed by unknown authority") ||
+				strings.Contains(err.Error(), "TLS handshake timeout") ||
+				strings.Contains(err.Error(), "certificate") ||
+				strings.Contains(err.Error(), "tls:")) {
+			// Retry with TLS verification disabled as a fallback
 			return getAuthTokenWithTlsDisabled(cfg)
 		}
+		tokenRenewInProgress = false
 		return "", err
 	}
 	defer resp.Body.Close()
@@ -196,6 +227,21 @@ func getAuthToken(cfg SecuritySettings) (string, error) {
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (err error) {
+	if serverName := endpointServerName(e.config.Endpoint); serverName != "" {
+		configuredServerName := strings.TrimSpace(e.config.ClientConfig.TLS.ServerName)
+		if configuredServerName == "" || strings.Contains(configuredServerName, ":") {
+			e.config.ClientConfig.TLS.ServerName = serverName
+		}
+	}
+
+	// Save original TLS settings — we handle TLS manually in the dialer so that
+	// gRPC's own TLS+proxy interception is bypassed completely. By forcing
+	// Insecure=true here gRPC treats the connection as plain TCP and never
+	// tries to establish its own HTTP-CONNECT tunnel, which would conflict with
+	// our manual CONNECT implementation below.
+	originalInsecure := e.config.ClientConfig.TLS.Insecure
+	originalSkipVerify := e.config.ClientConfig.TLS.InsecureSkipVerify
+	e.config.ClientConfig.TLS.Insecure = true
 
 	e.clientConn, err = e.config.ClientConfig.ToClientConn(
 		ctx,
@@ -203,21 +249,161 @@ func (e *opsrampOTLPExporter) start(ctx context.Context, host component.Host) (e
 		e.settings,
 		configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent)),
 		configgrpc.WithGrpcDialOption(
-			grpc.WithContextDialer(func(_ context.Context, addr string) (net.Conn, error) {
-				if httpproxy.FromEnvironment().HTTPProxy == "" {
-					return (&net.Dialer{}).Dial("tcp", addr)
+			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+				dialAddr := sanitizeDialAddress(addr)
+
+				// establishTLSConnection wraps a raw TCP dialer with a TLS handshake,
+				// falling back to InsecureSkipVerify on x509 errors when allowed.
+				establishTLSConnection := func(dialAddr string, redial func() (net.Conn, error)) (net.Conn, error) {
+					conn, err := redial()
+					if err != nil {
+						return nil, err
+					}
+					if originalInsecure {
+						return conn, nil
+					}
+					serverName := dialAddr
+					if colonIdx := strings.LastIndex(dialAddr, ":"); colonIdx != -1 {
+						serverName = dialAddr[:colonIdx]
+					}
+					tlsConn := tls.Client(conn, &tls.Config{
+						ServerName:         serverName,
+						InsecureSkipVerify: originalSkipVerify, // #nosec G402
+					})
+					if err := tlsConn.HandshakeContext(ctx); err != nil {
+						conn.Close()
+						if originalSkipVerify {
+							e.settings.Logger.Warn("TLS handshake failed (InsecureSkipVerify=true), bypassing TLS",
+								zap.String("addr", dialAddr), zap.Error(err))
+							conn, err = redial()
+							if err != nil {
+								return nil, err
+							}
+							return conn, nil
+						}
+						if strings.Contains(err.Error(), "x509:") {
+							e.settings.Logger.Warn("TLS x509 error, retrying with InsecureSkipVerify",
+								zap.String("addr", dialAddr), zap.Error(err))
+							conn, err = redial()
+							if err != nil {
+								return nil, err
+							}
+							tlsConn = tls.Client(conn, &tls.Config{
+								ServerName:         serverName,
+								InsecureSkipVerify: true, // #nosec G402
+							})
+							if err := tlsConn.HandshakeContext(ctx); err != nil {
+								conn.Close()
+								return nil, fmt.Errorf("TLS handshake failed (InsecureSkipVerify fallback): %w", err)
+							}
+							return tlsConn, nil
+						}
+						return nil, fmt.Errorf("TLS handshake failed: %w", err)
+					}
+					e.settings.Logger.Debug("TLS established (direct)",
+						zap.Uint16("version", tlsConn.ConnectionState().Version))
+					return tlsConn, nil
 				}
 
-				uri, er := url.Parse(httpproxy.FromEnvironment().HTTPProxy)
-				if er != nil {
-					return nil, er
+				// Bypass proxy for loopback addresses.
+				if shouldBypassProxy(dialAddr) {
+					return establishTLSConnection(dialAddr, func() (net.Conn, error) {
+						return (&net.Dialer{}).DialContext(ctx, "tcp", dialAddr)
+					})
 				}
 
-				dialer, er := proxy.FromURL(uri, proxy.Direct)
-				if er != nil {
-					return nil, er
+				// Resolve proxy URL from environment (HTTPS_PROXY for TLS, HTTP_PROXY for plain).
+				targetURL := &url.URL{Scheme: proxyLookupScheme(e.config.Endpoint, originalInsecure), Host: dialAddr}
+				proxyURL, err := httpproxy.FromEnvironment().ProxyFunc()(targetURL)
+				if err != nil {
+					return nil, fmt.Errorf("proxy resolution failed: %w", err)
 				}
-				return dialer.Dial("tcp", addr)
+				if proxyURL == nil {
+					return establishTLSConnection(dialAddr, func() (net.Conn, error) {
+						return (&net.Dialer{}).DialContext(ctx, "tcp", dialAddr)
+					})
+				}
+
+				e.settings.Logger.Debug("connecting via proxy",
+					zap.String("proxy", proxyURL.Host), zap.String("target", dialAddr),
+					zap.Bool("insecure", originalInsecure), zap.Bool("skipVerify", originalSkipVerify))
+
+				// establishProxyTunnel manually issues HTTP CONNECT with Proxy-Authorization.
+				// Using the standard library directly (rather than golang.org/x/net/proxy)
+				// ensures the Proxy-Authorization header is always sent correctly.
+				establishProxyTunnel := func() (net.Conn, error) {
+					conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", proxyURL.Host)
+					if err != nil {
+						return nil, fmt.Errorf("proxy dial failed: %w", err)
+					}
+					connectReq := &http.Request{
+						Method:     "CONNECT",
+						URL:        &url.URL{Host: dialAddr},
+						Host:       dialAddr,
+						Header:     make(http.Header),
+						Proto:      "HTTP/1.1",
+						ProtoMajor: 1,
+						ProtoMinor: 1,
+					}
+					if proxyURL.User != nil {
+						username := proxyURL.User.Username()
+						password, _ := proxyURL.User.Password()
+						connectReq.Header.Set("Proxy-Authorization", "Basic "+basicAuth(username, password))
+					}
+					if err := connectReq.Write(conn); err != nil {
+						conn.Close()
+						return nil, fmt.Errorf("proxy CONNECT write failed: %w", err)
+					}
+					br := bufio.NewReader(conn)
+					resp, err := http.ReadResponse(br, connectReq)
+					if err != nil {
+						conn.Close()
+						return nil, fmt.Errorf("proxy CONNECT read failed: %w", err)
+					}
+					resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						conn.Close()
+						return nil, fmt.Errorf("proxy CONNECT rejected: %s", resp.Status)
+					}
+					return &bufferedConn{Conn: conn, reader: br}, nil
+				}
+
+				tunnelConn, err := establishProxyTunnel()
+				if err != nil {
+					return nil, err
+				}
+
+				if originalInsecure {
+					return tunnelConn, nil
+				}
+
+				// Manual TLS handshake over the proxy tunnel.
+				serverName := dialAddr
+				if colonIdx := strings.LastIndex(dialAddr, ":"); colonIdx != -1 {
+					serverName = dialAddr[:colonIdx]
+				}
+				tlsConn := tls.Client(tunnelConn, &tls.Config{
+					ServerName:         serverName,
+					InsecureSkipVerify: originalSkipVerify, // #nosec G402
+				})
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					tunnelConn.Close()
+					if originalSkipVerify {
+						e.settings.Logger.Warn("TLS via proxy failed (InsecureSkipVerify=true), bypassing TLS",
+							zap.String("target", dialAddr), zap.Error(err))
+						tunnelConn, err = establishProxyTunnel()
+						if err != nil {
+							return nil, err
+						}
+						return tunnelConn, nil
+					}
+					return nil, fmt.Errorf("TLS handshake via proxy failed: %w", err)
+				}
+				e.settings.Logger.Debug("TLS established (via proxy)",
+					zap.Uint16("version", tlsConn.ConnectionState().Version),
+					zap.Bool("insecure", originalInsecure),
+					zap.Bool("skipVerify", originalSkipVerify))
+				return tlsConn, nil
 			})),
 	)
 	if err != nil {
@@ -427,7 +613,12 @@ func (e *opsrampOTLPExporter) pushLogs(_ context.Context, ld plog.Logs) error {
 }
 
 func (e *opsrampOTLPExporter) updateExpiredToken() error {
-	accessToken, err := getAuthToken(e.config.Security)
+	// Extract TLS options from the gRPC client config
+	tlsOpts := TLSOptions{
+		Insecure:           e.config.ClientConfig.TLS.Insecure,
+		InsecureSkipVerify: e.config.ClientConfig.TLS.InsecureSkipVerify,
+	}
+	accessToken, err := getAuthToken(e.config.Security, tlsOpts)
 	if err != nil {
 		return err
 	}
@@ -617,6 +808,74 @@ func getAuthTokenWithTlsDisabled(cfg SecuritySettings) (string, error) {
 	}
 
 	return credentials.AccessToken, nil
+}
+
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+type bufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *bufferedConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func proxyLookupScheme(endpoint string, insecure bool) string {
+	if strings.HasPrefix(endpoint, "http://") {
+		return "http"
+	}
+	if strings.HasPrefix(endpoint, "https://") {
+		return "https"
+	}
+	if insecure {
+		return "http"
+	}
+	return "https"
+}
+
+func sanitizeDialAddress(addr string) string {
+	for _, prefix := range []string{"dns:///", "passthrough:///"} {
+		if strings.HasPrefix(addr, prefix) {
+			return strings.TrimPrefix(addr, prefix)
+		}
+	}
+	return addr
+}
+
+func shouldBypassProxy(addr string) bool {
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func endpointServerName(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	if strings.Contains(endpoint, "://") {
+		u, err := url.Parse(endpoint)
+		if err == nil {
+			return u.Hostname()
+		}
+	}
+	host := endpoint
+	if idx := strings.Index(host, "/"); idx >= 0 {
+		host = host[:idx]
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return strings.Trim(h, "[]")
+	}
+	return strings.Trim(host, "[]")
 }
 
 func initLogger() *zap.Logger {

--- a/pkg/stanza/operator/input/windows/config_all.go
+++ b/pkg/stanza/operator/input/windows/config_all.go
@@ -58,6 +58,7 @@ type Config struct {
 	Raw                      bool            `mapstructure:"raw,omitempty"`
 	EventDataFormat          EventDataFormat `mapstructure:"event_data_format,omitempty"`
 	IncludeLogRecordOriginal bool            `mapstructure:"include_log_record_original,omitempty"`
+	ReqOrgAttr               *bool           `mapstructure:"req_org_attr,omitempty"`
 	SuppressRenderingInfo    bool            `mapstructure:"suppress_rendering_info,omitempty"`
 	ExcludeProviders         []string        `mapstructure:"exclude_providers,omitempty"`
 	Remote                   RemoteConfig    `mapstructure:"remote,omitempty"`

--- a/pkg/stanza/operator/input/windows/config_windows.go
+++ b/pkg/stanza/operator/input/windows/config_windows.go
@@ -69,6 +69,7 @@ func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, erro
 		raw:                      c.Raw,
 		eventDataFormat:          c.EventDataFormat,
 		includeLogRecordOriginal: c.IncludeLogRecordOriginal,
+		ReqOrgAttr:               c.ReqOrgAttr,
 		excludeProviders:         excludeProvidersSet(c.ExcludeProviders),
 		remote:                   c.Remote,
 		query:                    c.Query,

--- a/pkg/stanza/operator/input/windows/event.go
+++ b/pkg/stanza/operator/input/windows/event.go
@@ -171,6 +171,35 @@ func (e *Event) RenderRaw(buffer *Buffer) (EventRaw, error) {
 	return UnmarshalEventRaw(bytes)
 }
 
+// RenderFormattedRaw will render the event as raw XML with RenderingInfo included.
+// This uses the publisher to format the event, which populates RenderingInfo>Message.
+// Use this instead of RenderRaw when you want the human-readable message in raw mode.
+func (e *Event) RenderFormattedRaw(buffer *Buffer, publisher Publisher) (EventRaw, error) {
+	if e.handle == 0 {
+		return EventRaw{}, fmt.Errorf("event handle does not exist")
+	}
+
+	bufferUsed, err := evtFormatMessage(publisher.handle, e.handle, 0, 0, 0, EvtFormatMessageXML, buffer.SizeWide(), buffer.FirstByte())
+	if errors.Is(err, ErrorInsufficientBuffer) {
+		if *bufferUsed == 0 {
+			return EventRaw{}, errUnknownNextFrame
+		}
+		buffer.UpdateSizeWide(*bufferUsed)
+		return e.RenderFormattedRaw(buffer, publisher)
+	}
+
+	if err != nil {
+		return EventRaw{}, fmt.Errorf("syscall to 'EvtFormatMessage' failed: %w", err)
+	}
+
+	bytes, err := buffer.ReadWideChars(*bufferUsed)
+	if err != nil {
+		return EventRaw{}, fmt.Errorf("failed to read bytes from buffer: %w", err)
+	}
+
+	return UnmarshalEventRaw(bytes)
+}
+
 // Close will close the event handle.
 func (e *Event) Close() error {
 	if e.handle == 0 {

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -7,6 +7,7 @@ package windows // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sys/windows"
@@ -308,6 +308,8 @@ func (i *Input) readBatch(ctx context.Context) bool {
 	pstartedAt := pstartedAtObj.Format("2006-01-02 15:04:05.000")
 
 	for eI, event := range events {
+		// Always use RenderSimple to get full EventXML (needed for processEventWithSimple)
+		// This ensures we have EventData, RecordID, etc. for both raw and non-raw modes
 		parsedSimpleEvent, err := event.RenderSimple(i.buffer)
 		if err != nil {
 			i.Logger().Error("Failed to render simple event", zap.Error(err))
@@ -317,36 +319,45 @@ func (i *Input) readBatch(ctx context.Context) bool {
 
 		simpleEvent := parsedSimpleEvent.toEventXML()
 		recordID := simpleEvent.RecordID
-		dedupKey := fmt.Sprintf("dedup_%d", recordID)
-		// Deduplication: check if this record was already processed
-		exists, dCheckErr := i.persister.Get(ctx, dedupKey)
-		if dCheckErr != nil {
-			i.Logger().Error("Failed to check deduplication key", zap.Error(dCheckErr))
-			event.Close()
-			continue
-		}
-		if exists != nil {
-			i.Logger().Debug("Duplicate event, skipping", zap.Uint64("record_id", recordID))
-			event.Close()
-			continue
+		providerName := simpleEvent.Provider.Name
+
+		if recordID > 0 {
+			dedupKey := fmt.Sprintf("dedup_%d", recordID)
+			// Deduplication: check if this record was already processed
+			exists, dCheckErr := i.persister.Get(ctx, dedupKey)
+			if dCheckErr != nil {
+				i.Logger().Error("Failed to check deduplication key", zap.Error(dCheckErr))
+				event.Close()
+				continue
+			}
+			if exists != nil {
+				i.Logger().Debug("Duplicate event, skipping", zap.Uint64("record_id", recordID))
+				event.Close()
+				continue
+			}
 		}
 
 		// Skip empty events
-		if recordID == 0 && simpleEvent.Provider.Name == "" {
+		if recordID == 0 && providerName == "" {
 			i.Logger().Debug("Skipping empty event")
 			event.Close()
 			continue
 		}
 
+		// Always go through processEventWithSimple - it handles both raw and non-raw modes
+		// and attempts to get the formatted event (with RenderingInfo.Message) from the publisher
 		err1 := i.processEventWithSimple(ctx, event, simpleEvent)
 		if err1 == nil {
 			i.updateBookmarkOffset(ctx, event)
-			// Persist processed RecordID for deduplication
-			if err := i.persister.Set(ctx, dedupKey, []byte("1")); err != nil {
-				i.Logger().Error("Failed to persist deduplication key", zap.Error(err))
+			// Persist processed RecordID for deduplication (only when we have a valid recordID)
+			if recordID > 0 {
+				dedupKey := fmt.Sprintf("dedup_%d", recordID)
+				if err := i.persister.Set(ctx, dedupKey, []byte("1")); err != nil {
+					i.Logger().Error("Failed to persist deduplication key", zap.Error(err))
+				}
 			}
 		} else {
-			i.Logger().Error("Failed to process event", zap.Any("pstartedAt", pstartedAt), zap.Int("current loop id:", eI), zap.Any("process started at ", time.Now().Local().Format("2006-01-02 15:04:05.000")), zap.Uint64("record_id", recordID), zap.Error(err))
+			i.Logger().Error("Failed to process event", zap.Any("pstartedAt", pstartedAt), zap.Int("current loop id:", eI), zap.Any("process started at ", time.Now().Local().Format("2006-01-02 15:04:05.000")), zap.Uint64("record_id", recordID), zap.Error(err1))
 		}
 		event.Close()
 	}
@@ -451,9 +462,9 @@ func (i *Input) processEventWithRenderingInfo(ctx context.Context, event Event) 
 
 // sendEvent will send a parsedEvent as an entry to the operator's output.
 //
-// raw=true path: only event.getOriginal(), event.getSystemTime(), event.getLevel(),
-// and event.getRenderedLevel() are called. If you add a field access here that
-// runs when raw=true, add a corresponding method to parsedEvent and rawParsedEvent.
+// raw=true path: All getXxx() methods in parsedEvent interface are called.
+// If you add a field access here, add a corresponding method to parsedEvent
+// and rawEventXML.
 func (i *Input) sendEvent(ctx context.Context, event parsedEvent) error {
 	var body any = event.getOriginal()
 	if !i.raw {
@@ -468,16 +479,101 @@ func (i *Input) sendEvent(ctx context.Context, event parsedEvent) error {
 	e.Timestamp = parseTimestamp(event.getSystemTime())
 	e.Severity = parseSeverity(event.getRenderedLevel(), event.getLevel())
 
-	if i.remote.Server != "" {
-		e.AddAttribute("server.address", i.remote.Server)
+	// === Provider attributes ===
+	if providerName := event.getProviderName(); providerName != "" {
+		e.AddAttribute("event_name", providerName)
+		e.AddAttribute("provider_name", providerName)
+	}
+	if eventSourceName := event.getEventSourceName(); eventSourceName != "" {
+		e.AddAttribute("event_source_name", eventSourceName)
 	}
 
-	if i.includeLogRecordOriginal {
-		e.AddAttribute(string(conventions.LogRecordOriginalKey), event.getOriginal())
+	// === EventID attributes ===
+	if eventID := event.getEventID(); eventID != 0 {
+		e.AddAttribute("event_identifier", fmt.Sprintf("%d", eventID))
+		e.AddAttribute("event_id", fmt.Sprintf("%d", eventID))
+	}
+	if qualifiers := event.getEventIDQualifiers(); qualifiers != 0 {
+		e.AddAttribute("event_id_qualifiers", fmt.Sprintf("%d", qualifiers))
 	}
 
-	eventData, _ := i.ExtractEventData(event.toEventXML().EventData)
+	// === Channel ===
+	if channel := event.getChannel(); channel != "" {
+		e.AddAttribute("event_channel", channel)
+	}
+
+	// === Record and Version ===
+	if recordID := event.getRecordID(); recordID != 0 {
+		e.AddAttribute("record_id", fmt.Sprintf("%d", recordID))
+	}
+	if version := event.getVersion(); version != 0 {
+		e.AddAttribute("version", fmt.Sprintf("%d", version))
+	}
+
+	// === Level: source_level is raw numeric, level is text ===
+	if level := event.getLevel(); level != "" {
+		e.AddAttribute("source_level", level)     // Raw numeric: "0", "1", "2", "3", "4", "5"
+		e.AddAttribute("level", levelName(level)) // Text: "Information", "Error", "Warning", "Critical", "Verbose"
+	}
+	if renderedLevel := event.getRenderedLevel(); renderedLevel != "" {
+		e.AddAttribute("rendered_level", renderedLevel)
+	}
+
+	// === Task and Opcode ===
+	if task := event.getTask(); task != "" {
+		e.AddAttribute("task", task)
+	}
+	if renderedTask := event.getRenderedTask(); renderedTask != "" {
+		e.AddAttribute("rendered_task", renderedTask)
+	}
+	if opcode := event.getOpcode(); opcode != "" {
+		e.AddAttribute("opcode", opcode)
+	}
+	if renderedOpcode := event.getRenderedOpcode(); renderedOpcode != "" {
+		e.AddAttribute("rendered_opcode", renderedOpcode)
+	}
+
+	// === Rendered Keywords (human-readable keywords from RenderingInfo) ===
+	if renderedKeywords := event.getRenderedKeywords(); len(renderedKeywords) > 0 {
+		e.AddAttribute("rendered_keywords", strings.Join(renderedKeywords, ","))
+	}
+
+	// === Security: User ID (SID) ===
+	if userID := event.getUserID(); userID != "" {
+		e.AddAttribute("user_id", userID)
+	}
+
+	// === Execution: Process ID only ===
+	if processID := event.getProcessID(); processID != 0 {
+		e.AddAttribute("process_id", fmt.Sprintf("%d", processID))
+	}
+
+	// === Correlation: Activity IDs ===
+	if activityID := event.getActivityID(); activityID != "" {
+		e.AddAttribute("activity_id", activityID)
+	}
+	if relatedActivityID := event.getRelatedActivityID(); relatedActivityID != "" {
+		e.AddAttribute("related_activity_id", relatedActivityID)
+	}
+
+	// === Rendered Message ===
+	if message := event.getRenderedMessage(); message != "" {
+		e.AddAttribute("rendered_message", message)
+	}
+
+	// === Binary Event Data ===
+	if binaryData := event.getBinaryEventData(); binaryData != "" {
+		e.AddAttribute("binary_event_data", binaryData)
+	}
+
+	// === EventData fields as individual attributes ===
+	eventData, _ := i.ExtractEventData(event.getEventData())
 	if len(eventData) > 0 {
+		// Add event_data as JSON-encoded structured attribute
+		if eventDataJSON, err := json.Marshal(eventData); err == nil {
+			e.AddAttribute("event_data", string(eventDataJSON))
+		}
+		// Also add individual fields as flat attributes
 		for eK, eD := range eventData {
 			eK = strings.ReplaceAll(strings.ToLower(eK), " ", "_")
 			if str, ok := eD.(string); ok {
@@ -487,6 +583,22 @@ func (i *Input) sendEvent(ctx context.Context, event parsedEvent) error {
 			}
 		}
 	}
+
+	// === UserData fields as individual attributes ===
+	if userData := event.getUserData(); userData != nil {
+		if userData.Name != "" {
+			e.AddAttribute("userdata_name", userData.Name)
+		}
+		for k, v := range userData.Data {
+			attrKey := "userdata_" + strings.ReplaceAll(strings.ToLower(k), " ", "_")
+			e.AddAttribute(attrKey, v)
+		}
+	}
+
+	if i.remote.Server != "" {
+		e.AddAttribute("server.address", i.remote.Server)
+	}
+
 	if i.isAdditionalAttrReq() {
 		e.AddAttribute("log_record_original", event.getOriginal())
 	}
@@ -544,7 +656,37 @@ func (i *Input) isAdditionalAttrReq() bool {
 
 func (i *Input) ExtractEventData(eventData EventData) (map[string]any, error) {
 	result := make(map[string]any)
+
+	// Include EventData name if present
+	if eventData.Name != "" {
+		result["name"] = eventData.Name
+	}
+
+	// Include binary data if present
+	if eventData.Binary != "" {
+		result["binary"] = eventData.Binary
+	}
+
+	// Collect anonymous data values into message
+	var messageValues []string
+
 	for _, data := range eventData.Data {
+		// Handle anonymous data (no Name attribute) - aggregate into message
+		if data.Name == "" {
+			if data.Value != "" {
+				messageValues = append(messageValues, data.Value)
+			}
+			continue
+		}
+
+		// Skip unwanted fields
+		switch data.Name {
+		case "CountOfCredentialsReturned", "ProcessCreationTime", "ReadOperation", "SubjectDomainName":
+			// Skip these fields
+			continue
+		}
+
+		// Extract known named fields with normalized keys
 		switch data.Name {
 		case "LogonType":
 			result["logon_type"] = data.Value
@@ -556,28 +698,28 @@ func (i *Input) ExtractEventData(eventData EventData) (map[string]any, error) {
 			result["security_id"] = data.Value
 		case "LogonID", "TargetLogonId", "SubjectLogonId":
 			result["logon_id"] = data.Value
-		case "TargetUserName":
+		case "TargetUserName", "SubjectUserName":
 			result["user_name"] = data.Value
 		case "TargetDomainName", "WorkstationName":
 			result["domain_name"] = data.Value
+		default:
+			// Include all other named fields with normalized key (lowercase, spaces to underscores)
+			key := strings.ReplaceAll(strings.ToLower(data.Name), " ", "_")
+			result[key] = data.Value
 		}
 	}
+
+	// Set message from anonymous data
+	if len(messageValues) > 0 {
+		result["message"] = strings.Join(messageValues, "\n")
+	}
+
 	return result, nil
 }
 
 func (i *Input) processEventWithSimple(ctx context.Context, event Event, simpleEvent *EventXML) error {
-	if i.raw {
-		rawEvent, err := event.RenderRaw(i.buffer)
-		if err != nil {
-			i.Logger().Error("Failed to render raw event", zap.Error(err))
-			return err
-		}
-		i.sendEventRaw(ctx, rawEvent)
-		return nil
-	}
-
 	isExcluded := func(providerName string) bool {
-		for excludeProvider, _ := range i.excludeProviders {
+		for excludeProvider := range i.excludeProviders {
 			if providerName == excludeProvider {
 				return true
 			}
@@ -590,29 +732,243 @@ func (i *Input) processEventWithSimple(ctx context.Context, event Event, simpleE
 		return nil
 	}
 
+	// For both raw and non-raw modes, try to get formatted event with RenderingInfo
+	// This ensures we get the localized message from Windows Event API
 	publisher, err := i.publisherCache.get(simpleEvent.Provider.Name)
 	if err != nil || !publisher.Valid() {
-		i.Logger().Warn("Fallback to simple event due to invalid publisher", zap.Error(err))
+		i.Logger().Debug("Publisher unavailable, using simple event",
+			zap.String("provider", simpleEvent.Provider.Name),
+			zap.String("channel", simpleEvent.Channel),
+			zap.Error(err))
+		if i.raw {
+			return i.sendEventXMLAsRaw(ctx, simpleEvent)
+		}
 		return i.sendEvent(ctx, simpleEvent)
 	}
 
 	formattedEvent, err := event.RenderFormatted(i.buffer, publisher)
 	if err != nil {
-		i.Logger().Error("Failed to render formatted event", zap.Error(err))
+		i.Logger().Debug("RenderFormatted failed, using simple event",
+			zap.String("provider", simpleEvent.Provider.Name),
+			zap.String("channel", simpleEvent.Channel),
+			zap.Error(err))
+		if i.raw {
+			return i.sendEventXMLAsRaw(ctx, simpleEvent)
+		}
 		return i.sendEvent(ctx, simpleEvent)
+	}
+
+	if i.raw {
+		return i.sendEventXMLAsRaw(ctx, formattedEvent)
 	}
 	return i.sendEvent(ctx, formattedEvent)
 }
 
+// sendEventXMLAsRaw sends EventXML in raw mode - body is the original XML,
+// but attributes are extracted from the parsed EventXML (including RenderingInfo.Message)
+func (i *Input) sendEventXMLAsRaw(ctx context.Context, eventXML *EventXML) error {
+	// Body is the original XML string
+	body := eventXML.Original
+	e, err := i.NewEntry(body)
+	if err != nil {
+		i.Logger().Error("Failed to create entry", zap.Error(err))
+		return err
+	}
+
+	// Get rendered values from RenderingInfo if available
+	var renderedLevel, renderedTask, renderedOpcode, renderedMessage string
+	var renderedKeywords []string
+	if eventXML.RenderingInfo != nil {
+		renderedLevel = eventXML.RenderingInfo.Level
+		renderedTask = eventXML.RenderingInfo.Task
+		renderedOpcode = eventXML.RenderingInfo.Opcode
+		renderedMessage = eventXML.RenderingInfo.Message
+		renderedKeywords = eventXML.RenderingInfo.Keywords
+	}
+
+	e.Timestamp = parseTimestamp(eventXML.TimeCreated.SystemTime)
+	e.Severity = parseSeverity(renderedLevel, eventXML.Level)
+
+	// === System Time ===
+	if systemTime := eventXML.TimeCreated.SystemTime; systemTime != "" {
+		e.AddAttribute("system_time", systemTime)
+	}
+
+	// === Provider attributes ===
+	if providerName := eventXML.Provider.Name; providerName != "" {
+		e.AddAttribute("provider_name", providerName)
+	}
+
+	// === EventID ===
+	if eventID := eventXML.EventID.ID; eventID != 0 {
+		e.AddAttribute("event_id", fmt.Sprintf("%d", eventID))
+	}
+
+	// === Channel ===
+	if channel := eventXML.Channel; channel != "" {
+		e.AddAttribute("channel", channel)
+	}
+
+	// === Computer ===
+	if computer := eventXML.Computer; computer != "" {
+		e.AddAttribute("computer", computer)
+	}
+
+	// === Record ID ===
+	if recordID := eventXML.RecordID; recordID != 0 {
+		e.AddAttribute("record_id", fmt.Sprintf("%d", recordID))
+	}
+
+	// === Level: prefer rendered (localized), fallback to numeric ===
+	if renderedLevel != "" {
+		e.AddAttribute("level", renderedLevel)
+	} else if level := eventXML.Level; level != "" {
+		e.AddAttribute("source_level", level)
+		e.AddAttribute("level", levelName(level))
+	}
+
+	// === Task: prefer rendered (localized), fallback to numeric ===
+	if renderedTask != "" {
+		e.AddAttribute("task", renderedTask)
+	} else if task := eventXML.Task; task != "" {
+		e.AddAttribute("task", task)
+	}
+
+	// === Opcode: prefer rendered (localized), fallback to numeric ===
+	if renderedOpcode != "" {
+		e.AddAttribute("opcode", renderedOpcode)
+	} else if opcode := eventXML.Opcode; opcode != "" {
+		e.AddAttribute("opcode", opcode)
+	}
+
+	// === Keywords ===
+	if len(renderedKeywords) > 0 {
+		e.AddAttribute("keywords", strings.Join(renderedKeywords, ","))
+	}
+
+	// === Security: User ID (SID) ===
+	if eventXML.Security != nil && eventXML.Security.UserID != "" {
+		e.AddAttribute("user_id", eventXML.Security.UserID)
+	}
+
+	// === Message (from RenderingInfo - localized by Windows via EvtFormatMessage) ===
+	if renderedMessage != "" {
+		e.AddAttribute("message", renderedMessage)
+	}
+
+	// === EventData fields as individual attributes ===
+	eventData, _ := i.ExtractEventData(eventXML.EventData)
+	for eK, eD := range eventData {
+		eK = strings.ReplaceAll(strings.ToLower(eK), " ", "_")
+		if str, ok := eD.(string); ok {
+			e.AddAttribute(eK, str)
+		} else {
+			e.AddAttribute(eK, fmt.Sprintf("%v", eD))
+		}
+	}
+
+	if i.remote.Server != "" {
+		e.AddAttribute("server.address", i.remote.Server)
+	}
+
+	if i.isAdditionalAttrReq() {
+		e.AddAttribute("log_record_original", eventXML.Original)
+	}
+
+	i.Write(ctx, e)
+	return nil
+}
+
 func (i *Input) sendEventRaw(ctx context.Context, eventRaw EventRaw) {
 	body := eventRaw.parseBody()
-	entry, err := i.NewEntry(body)
+	e, err := i.NewEntry(body)
 	if err != nil {
 		i.Logger().Error("Failed to create entry", zap.Error(err))
 		return
 	}
 
-	entry.Timestamp = eventRaw.ParseTimestamp()
-	entry.Severity = eventRaw.ParseRenderedSeverity()
-	i.Write(ctx, entry)
+	e.Timestamp = eventRaw.ParseTimestamp()
+	e.Severity = eventRaw.ParseRenderedSeverity()
+
+	// === System Time ===
+	if systemTime := eventRaw.TimeCreated.SystemTime; systemTime != "" {
+		e.AddAttribute("system_time", systemTime)
+	}
+
+	// === Provider attributes ===
+	if providerName := eventRaw.GetProviderName(); providerName != "" {
+		e.AddAttribute("provider_name", providerName)
+	}
+
+	// === EventID ===
+	if eventID := eventRaw.GetEventID(); eventID != 0 {
+		e.AddAttribute("event_id", fmt.Sprintf("%d", eventID))
+	}
+
+	// === Channel ===
+	if channel := eventRaw.GetChannel(); channel != "" {
+		e.AddAttribute("channel", channel)
+	}
+
+	// === Computer ===
+	if computer := eventRaw.GetComputer(); computer != "" {
+		e.AddAttribute("computer", computer)
+	}
+
+	// === Record ID ===
+	if recordID := eventRaw.GetRecordID(); recordID != 0 {
+		e.AddAttribute("record_id", fmt.Sprintf("%d", recordID))
+	}
+
+	// === Level: source_level is raw numeric, level is text ===
+	if level := eventRaw.Level; level != "" {
+		e.AddAttribute("source_level", level)     // Raw numeric: "0", "1", "2", "3", "4", "5"
+		e.AddAttribute("level", levelName(level)) // Text: "Information", "Error", "Warning", "Critical", "Verbose"
+	}
+
+	// === Task: prefer rendered text over numeric ===
+	if renderedTask := eventRaw.GetRenderedTask(); renderedTask != "" {
+		e.AddAttribute("task", renderedTask)
+	} else if task := eventRaw.GetTask(); task != "" {
+		e.AddAttribute("task", task)
+	}
+
+	// === Opcode: prefer rendered text over numeric ===
+	if renderedOpcode := eventRaw.GetRenderedOpcode(); renderedOpcode != "" {
+		e.AddAttribute("opcode", renderedOpcode)
+	} else if opcode := eventRaw.GetOpcode(); opcode != "" {
+		e.AddAttribute("opcode", opcode)
+	}
+
+	// === Keywords ===
+	if renderedKeywords := eventRaw.GetRenderedKeywords(); len(renderedKeywords) > 0 {
+		e.AddAttribute("keywords", strings.Join(renderedKeywords, ","))
+	}
+
+	// === Security: User ID (SID) ===
+	if userID := eventRaw.GetUserID(); userID != "" {
+		e.AddAttribute("user_id", userID)
+	}
+
+	// === Message ===
+	if message := eventRaw.GetRenderedMessage(); message != "" {
+		e.AddAttribute("message", message)
+	}
+
+	// === EventData fields as individual attributes ===
+	eventData, _ := i.ExtractEventData(eventRaw.GetEventData())
+	for eK, eD := range eventData {
+		eK = strings.ReplaceAll(strings.ToLower(eK), " ", "_")
+		if str, ok := eD.(string); ok {
+			e.AddAttribute(eK, str)
+		} else {
+			e.AddAttribute(eK, fmt.Sprintf("%v", eD))
+		}
+	}
+
+	if i.remote.Server != "" {
+		e.AddAttribute("server.address", i.remote.Server)
+	}
+
+	i.Write(ctx, e)
 }

--- a/pkg/stanza/operator/input/windows/raw.go
+++ b/pkg/stanza/operator/input/windows/raw.go
@@ -6,17 +6,50 @@ package windows // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"encoding/xml"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 )
 
-// EventRaw is the rendered xml of an event, however, its message is the original XML of the entire event.
+// EventRaw is the rendered xml of an event with all fields parsed for attribute extraction.
+// The body is the original XML of the entire event.
 type EventRaw struct {
-	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
-	RenderedLevel string      `xml:"RenderingInfo>Level"`
-	Level         string      `xml:"System>Level"`
-	Body          string      `xml:"-"`
+	// System fields
+	TimeCreated TimeCreated  `xml:"System>TimeCreated"`
+	Level       string       `xml:"System>Level"`
+	Provider    Provider     `xml:"System>Provider"`
+	EventID     EventID      `xml:"System>EventID"`
+	Channel     string       `xml:"System>Channel"`
+	Computer    string       `xml:"System>Computer"`
+	RecordID    uint64       `xml:"System>EventRecordID"`
+	Task        string       `xml:"System>Task"`
+	Opcode      string       `xml:"System>Opcode"`
+	Keywords    string       `xml:"System>Keywords"`
+	Version     uint8        `xml:"System>Version"`
+	Security    *Security    `xml:"System>Security"`
+	Execution   *Execution   `xml:"System>Execution"`
+	Correlation *Correlation `xml:"System>Correlation"`
+
+	// Data fields
+	EventData       EventData `xml:"EventData"`
+	UserData        *UserData `xml:"UserData"`
+	BinaryEventData string    `xml:"BinaryEventData"`
+
+	// RenderingInfo (populated when using RenderFormattedRaw with publisher)
+	RenderingInfo *RenderingInfoRaw `xml:"RenderingInfo"`
+
+	// Body stores the original XML
+	Body string `xml:"-"`
+}
+
+// RenderingInfoRaw holds rendered fields from RenderingInfo for raw mode.
+type RenderingInfoRaw struct {
+	Level    string   `xml:"Level"`
+	Message  string   `xml:"Message"`
+	Task     string   `xml:"Task"`
+	Opcode   string   `xml:"Opcode"`
+	Keywords []string `xml:"Keywords>Keyword"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -27,11 +60,26 @@ func (e *EventRaw) ParseTimestamp() time.Time {
 	return time.Now()
 }
 
-// parseRenderedSeverity will parse the severity of the event.
+// ParseRenderedSeverity returns the severity of the event.
+// Prefers numeric level (more reliable across localized Windows installations)
+// over rendered text, falling back to text only when numeric is unavailable.
 func (e *EventRaw) ParseRenderedSeverity() entry.Severity {
-	switch e.RenderedLevel {
-	case "":
-		return e.ParseSeverity()
+	// Prefer numeric level first (more reliable than localized text)
+	switch e.Level {
+	case "1":
+		return entry.Fatal
+	case "2":
+		return entry.Error
+	case "3":
+		return entry.Warn
+	case "0", "4":
+		return entry.Info
+	case "5":
+		return entry.Debug // Verbose
+	}
+	// Fallback to rendered text when numeric level is empty/unknown
+	renderedLevel := e.GetRenderedLevel()
+	switch renderedLevel {
 	case "Critical":
 		return entry.Fatal
 	case "Error":
@@ -40,14 +88,15 @@ func (e *EventRaw) ParseRenderedSeverity() entry.Severity {
 		return entry.Warn
 	case "Information":
 		return entry.Info
-	default:
-		return entry.Default
 	}
+	return entry.Default
 }
 
 // parseSeverity will parse the severity of the event when RenderingInfo is not populated
 func (e *EventRaw) ParseSeverity() entry.Severity {
 	switch e.Level {
+	case "0":
+		return entry.Info // LogAlways - used by Security audit events
 	case "1":
 		return entry.Fatal
 	case "2":
@@ -56,6 +105,8 @@ func (e *EventRaw) ParseSeverity() entry.Severity {
 		return entry.Warn
 	case "4":
 		return entry.Info
+	case "5":
+		return entry.Debug // Verbose
 	default:
 		return entry.Default
 	}
@@ -65,12 +116,121 @@ func (e *EventRaw) parseBody() string {
 	return e.Body
 }
 
+// === Getter methods for attribute extraction ===
+
+func (e *EventRaw) GetProviderName() string      { return e.Provider.Name }
+func (e *EventRaw) GetProviderGUID() string      { return e.Provider.GUID }
+func (e *EventRaw) GetEventSourceName() string   { return e.Provider.EventSourceName }
+func (e *EventRaw) GetEventID() uint32           { return e.EventID.ID }
+func (e *EventRaw) GetEventIDQualifiers() uint16 { return e.EventID.Qualifiers }
+func (e *EventRaw) GetChannel() string           { return e.Channel }
+func (e *EventRaw) GetComputer() string          { return e.Computer }
+func (e *EventRaw) GetRecordID() uint64          { return e.RecordID }
+func (e *EventRaw) GetTask() string              { return e.Task }
+func (e *EventRaw) GetOpcode() string            { return e.Opcode }
+func (e *EventRaw) GetKeywords() string          { return e.Keywords }
+func (e *EventRaw) GetVersion() uint8            { return e.Version }
+func (e *EventRaw) GetBinaryEventData() string   { return e.BinaryEventData }
+func (e *EventRaw) GetEventData() EventData      { return e.EventData }
+func (e *EventRaw) GetUserData() *UserData       { return e.UserData }
+
+func (e *EventRaw) GetRenderedLevel() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Level
+	}
+	return ""
+}
+
+func (e *EventRaw) GetRenderedMessage() string {
+	// First try RenderingInfo.Message (available when RenderFormattedRaw succeeds)
+	if e.RenderingInfo != nil && e.RenderingInfo.Message != "" {
+		return e.RenderingInfo.Message
+	}
+
+	// Fallback: construct message from EventData fields (locale-neutral)
+	// This works for Security/Setup channels where EvtFormatMessage may fail due to permissions
+	if len(e.EventData.Data) > 0 {
+		var parts []string
+		for _, d := range e.EventData.Data {
+			if d.Name != "" && d.Value != "" {
+				parts = append(parts, d.Name+": "+d.Value)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, ", ")
+		}
+	}
+	return ""
+}
+
+func (e *EventRaw) GetRenderedTask() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Task
+	}
+	return ""
+}
+
+func (e *EventRaw) GetRenderedOpcode() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Opcode
+	}
+	return ""
+}
+
+func (e *EventRaw) GetRenderedKeywords() []string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Keywords
+	}
+	return nil
+}
+
+func (e *EventRaw) GetUserID() string {
+	if e.Security != nil {
+		return e.Security.UserID
+	}
+	return ""
+}
+
+func (e *EventRaw) GetProcessID() uint {
+	if e.Execution != nil {
+		return e.Execution.ProcessID
+	}
+	return 0
+}
+
+func (e *EventRaw) GetThreadID() uint {
+	if e.Execution != nil {
+		return e.Execution.ThreadID
+	}
+	return 0
+}
+
+func (e *EventRaw) GetActivityID() string {
+	if e.Correlation != nil && e.Correlation.ActivityID != nil {
+		return *e.Correlation.ActivityID
+	}
+	return ""
+}
+
+func (e *EventRaw) GetRelatedActivityID() string {
+	if e.Correlation != nil && e.Correlation.RelatedActivityID != nil {
+		return *e.Correlation.RelatedActivityID
+	}
+	return ""
+}
+
 // unmarshalEventRaw will unmarshal EventRaw from xml bytes.
+// Uses sanitizeXMLBytes to strip the default namespace so that Go's xml package
+// can correctly match XML paths like "System>Level".
 func UnmarshalEventRaw(bytes []byte) (EventRaw, error) {
+	// Sanitize XML to strip namespace and illegal characters
+	sanitized := sanitizeXMLBytes(bytes)
+
 	var eventRaw EventRaw
-	if err := xml.Unmarshal(bytes, &eventRaw); err != nil {
+	if err := xml.Unmarshal(sanitized, &eventRaw); err != nil {
 		return EventRaw{}, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
 	}
+	// Keep original XML as the body
 	eventRaw.Body = string(bytes)
 	return eventRaw, nil
 }

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -22,15 +23,10 @@ type EventXML struct {
 	Channel             string               `xml:"System>Channel"`
 	RecordID            uint64               `xml:"System>EventRecordID"`
 	TimeCreated         TimeCreated          `xml:"System>TimeCreated"`
-	Message             string               `xml:"RenderingInfo>Message"`
-	RenderedLevel       string               `xml:"RenderingInfo>Level"`
-	RenderedTask        string               `xml:"RenderingInfo>Task"`
-	RenderedOpcode      string               `xml:"RenderingInfo>Opcode"`
-	RenderedKeywords    []string             `xml:"RenderingInfo>Keywords>Keyword"`
 	Level               string               `xml:"System>Level"`
 	Task                string               `xml:"System>Task"`
 	Opcode              string               `xml:"System>Opcode"`
-	Keywords            []string             `xml:"System>Keywords"`
+	Keywords            string               `xml:"System>Keywords"`
 	Security            *Security            `xml:"System>Security"`
 	Execution           *Execution           `xml:"System>Execution"`
 	EventData           EventData            `xml:"EventData"`
@@ -59,6 +55,8 @@ func parseTimestamp(ts string) time.Time {
 func parseSeverity(renderedLevel, level string) entry.Severity {
 	// Prefer numeric level first (more reliable than localized text)
 	switch level {
+	case "0":
+		return entry.Info // LogAlways - used by Security audit events
 	case "1":
 		return entry.Fatal
 	case "2":
@@ -84,13 +82,34 @@ func parseSeverity(renderedLevel, level string) entry.Severity {
 	return entry.Default
 }
 
+// levelName maps a Windows ETW numeric level string to its canonical English name.
+// Level 0 (LogAlways) returns "" because the Security channel and some other
+// providers use keywords (Audit Success/Failure) instead of a severity level.
+// Non-numeric values (e.g. already-rendered text) are returned unchanged.
+func levelName(level string) string {
+	switch level {
+	case "1":
+		return "Critical"
+	case "2":
+		return "Error"
+	case "3":
+		return "Warning"
+	case "0", "4":
+		return "Information"
+	case "5":
+		return "Verbose"
+	}
+	return level
+}
+
 // formattedBody will parse a body from the event.
 func formattedBody(e *EventXML, eventDataFormat EventDataFormat) map[string]any {
 	var rawMessage string
-	level := e.Level
+	level := levelName(e.Level)
 	task := e.Task
 	opcode := e.Opcode
-	keywords := e.Keywords
+	keywords := e.Keywords // System Keywords is a hex string
+	var renderedKeywords []string
 
 	if e.RenderingInfo != nil {
 		rawMessage = e.RenderingInfo.Message
@@ -104,11 +123,30 @@ func formattedBody(e *EventXML, eventDataFormat EventDataFormat) map[string]any 
 			opcode = e.RenderingInfo.Opcode
 		}
 		if e.RenderingInfo.Keywords != nil {
-			keywords = e.RenderingInfo.Keywords
+			renderedKeywords = e.RenderingInfo.Keywords
 		}
 	}
 
 	message, details := parseMessage(e.Channel, rawMessage)
+
+	// When the publisher DLL is unavailable (simple render path), RenderingInfo.Message
+	// is empty. Fall back to serializing named EventData fields (e.g. TargetUserName,
+	// LogonType) as "Key: Value" pairs so the body message is never completely empty.
+	if message == "" && len(e.EventData.Data) > 0 {
+		var parts []string
+		for _, d := range e.EventData.Data {
+			if d.Name != "" && d.Value != "" {
+				parts = append(parts, d.Name+": "+d.Value)
+			}
+		}
+		message = strings.Join(parts, ", ")
+	}
+
+	// Use rendered keywords if available, otherwise use hex string
+	var keywordsValue any = keywords
+	if len(renderedKeywords) > 0 {
+		keywordsValue = renderedKeywords
+	}
 
 	body := map[string]any{
 		"event_id": map[string]any{
@@ -128,7 +166,7 @@ func formattedBody(e *EventXML, eventDataFormat EventDataFormat) map[string]any 
 		"message":     message,
 		"task":        task,
 		"opcode":      opcode,
-		"keywords":    keywords,
+		"keywords":    keywordsValue,
 		"event_data":  parseEventData(e.EventData, eventDataFormat),
 		"version":     e.Version,
 	}
@@ -471,21 +509,115 @@ type parsedEvent interface {
 	getSystemTime() string
 	getLevel() string
 	getRenderedLevel() string
+	getProviderName() string
+	getProviderGUID() string
+	getEventSourceName() string
+	getEventID() uint32
+	getEventIDQualifiers() uint16
+	getChannel() string
+	getComputer() string
+	getRecordID() uint64
+	getUserID() string
+	getProcessID() uint
+	getThreadID() uint
+	getTask() string
+	getOpcode() string
+	getKeywords() string
+	getVersion() uint8
+	getActivityID() string
+	getRelatedActivityID() string
+	getRenderedMessage() string
+	getRenderedTask() string
+	getRenderedOpcode() string
+	getRenderedKeywords() []string
+	getUserData() *UserData
+	getBinaryEventData() string
+	getEventData() EventData
 	// formattedBody returns the structured body map for non-raw mode.
 	// Panics if called on rawParsedEvent — only valid when raw=false.
 	toEventXML() *EventXML
 }
 
-func (e *EventXML) getOriginal() string   { return e.Original }
-func (e *EventXML) getSystemTime() string { return e.TimeCreated.SystemTime }
-func (e *EventXML) getLevel() string      { return e.Level }
+func (e *EventXML) getOriginal() string          { return e.Original }
+func (e *EventXML) getSystemTime() string        { return e.TimeCreated.SystemTime }
+func (e *EventXML) getLevel() string             { return e.Level }
+func (e *EventXML) getProviderName() string      { return e.Provider.Name }
+func (e *EventXML) getProviderGUID() string      { return e.Provider.GUID }
+func (e *EventXML) getEventSourceName() string   { return e.Provider.EventSourceName }
+func (e *EventXML) getEventID() uint32           { return e.EventID.ID }
+func (e *EventXML) getEventIDQualifiers() uint16 { return e.EventID.Qualifiers }
+func (e *EventXML) getChannel() string           { return e.Channel }
+func (e *EventXML) getComputer() string          { return e.Computer }
+func (e *EventXML) getRecordID() uint64          { return e.RecordID }
+func (e *EventXML) getTask() string              { return e.Task }
+func (e *EventXML) getOpcode() string            { return e.Opcode }
+func (e *EventXML) getKeywords() string          { return e.Keywords }
+func (e *EventXML) getVersion() uint8            { return e.Version }
+func (e *EventXML) getBinaryEventData() string   { return e.BinaryEventData }
+func (e *EventXML) getEventData() EventData      { return e.EventData }
+func (e *EventXML) toEventXML() *EventXML        { return e }
+
 func (e *EventXML) getRenderedLevel() string {
 	if e.RenderingInfo != nil {
 		return e.RenderingInfo.Level
 	}
 	return ""
 }
-func (e *EventXML) toEventXML() *EventXML { return e }
+func (e *EventXML) getRenderedMessage() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Message
+	}
+	return ""
+}
+func (e *EventXML) getRenderedTask() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Task
+	}
+	return ""
+}
+func (e *EventXML) getRenderedOpcode() string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Opcode
+	}
+	return ""
+}
+func (e *EventXML) getRenderedKeywords() []string {
+	if e.RenderingInfo != nil {
+		return e.RenderingInfo.Keywords
+	}
+	return nil
+}
+func (e *EventXML) getUserID() string {
+	if e.Security != nil {
+		return e.Security.UserID
+	}
+	return ""
+}
+func (e *EventXML) getProcessID() uint {
+	if e.Execution != nil {
+		return e.Execution.ProcessID
+	}
+	return 0
+}
+func (e *EventXML) getThreadID() uint {
+	if e.Execution != nil {
+		return e.Execution.ThreadID
+	}
+	return 0
+}
+func (e *EventXML) getActivityID() string {
+	if e.Correlation != nil && e.Correlation.ActivityID != nil {
+		return *e.Correlation.ActivityID
+	}
+	return ""
+}
+func (e *EventXML) getRelatedActivityID() string {
+	if e.Correlation != nil && e.Correlation.RelatedActivityID != nil {
+		return *e.Correlation.RelatedActivityID
+	}
+	return ""
+}
+func (e *EventXML) getUserData() *UserData { return e.UserData }
 
 // unmarshalEventXML will unmarshal EventXML from xml bytes.
 // Illegal XML 1.0 characters (e.g. U+0001 found in some Sysmon events) are
@@ -502,28 +634,115 @@ func UnmarshalEventXML(data []byte) (parsedEvent, error) {
 	return eventXML, nil
 }
 
-// rawEventXML holds only the fields needed when raw=true, avoiding the
-// allocation and parsing cost of the full EventXML struct. The RenderingInfo
-// field carries just the rendered level, which is used for severity even in
-// raw mode when the deep render path is active.
+// rawEventXML holds the fields needed when raw=true. Includes all System fields
+// plus EventData, UserData, and RenderingInfo for comprehensive attribute extraction.
 type rawEventXML struct {
-	Original      string               `xml:"-"`
-	TimeCreated   TimeCreated          `xml:"System>TimeCreated"`
-	Level         string               `xml:"System>Level"`
-	RenderingInfo *rawRenderingInfoXML `xml:"RenderingInfo"`
+	Original        string               `xml:"-"`
+	TimeCreated     TimeCreated          `xml:"System>TimeCreated"`
+	Level           string               `xml:"System>Level"`
+	Provider        Provider             `xml:"System>Provider"`
+	EventID         EventID              `xml:"System>EventID"`
+	Channel         string               `xml:"System>Channel"`
+	Computer        string               `xml:"System>Computer"`
+	RecordID        uint64               `xml:"System>EventRecordID"`
+	Task            string               `xml:"System>Task"`
+	Opcode          string               `xml:"System>Opcode"`
+	Keywords        string               `xml:"System>Keywords"`
+	Version         uint8                `xml:"System>Version"`
+	Security        *Security            `xml:"System>Security"`
+	Execution       *Execution           `xml:"System>Execution"`
+	Correlation     *Correlation         `xml:"System>Correlation"`
+	EventData       EventData            `xml:"EventData"`
+	UserData        *UserData            `xml:"UserData"`
+	BinaryEventData string               `xml:"BinaryEventData"`
+	RenderingInfo   *rawRenderingInfoXML `xml:"RenderingInfo"`
 }
 
-// rawRenderingInfoXML holds only the Level field from RenderingInfo.
+// rawRenderingInfoXML holds rendered fields from RenderingInfo for raw mode.
 type rawRenderingInfoXML struct {
-	Level string `xml:"Level"`
+	Level    string   `xml:"Level"`
+	Message  string   `xml:"Message"`
+	Task     string   `xml:"Task"`
+	Opcode   string   `xml:"Opcode"`
+	Keywords []string `xml:"Keywords>Keyword"`
 }
 
-func (r *rawEventXML) getOriginal() string   { return r.Original }
-func (r *rawEventXML) getSystemTime() string { return r.TimeCreated.SystemTime }
-func (r *rawEventXML) getLevel() string      { return r.Level }
+func (r *rawEventXML) getOriginal() string          { return r.Original }
+func (r *rawEventXML) getSystemTime() string        { return r.TimeCreated.SystemTime }
+func (r *rawEventXML) getLevel() string             { return r.Level }
+func (r *rawEventXML) getProviderName() string      { return r.Provider.Name }
+func (r *rawEventXML) getProviderGUID() string      { return r.Provider.GUID }
+func (r *rawEventXML) getEventSourceName() string   { return r.Provider.EventSourceName }
+func (r *rawEventXML) getEventID() uint32           { return r.EventID.ID }
+func (r *rawEventXML) getEventIDQualifiers() uint16 { return r.EventID.Qualifiers }
+func (r *rawEventXML) getChannel() string           { return r.Channel }
+func (r *rawEventXML) getComputer() string          { return r.Computer }
+func (r *rawEventXML) getRecordID() uint64          { return r.RecordID }
+func (r *rawEventXML) getTask() string              { return r.Task }
+func (r *rawEventXML) getOpcode() string            { return r.Opcode }
+func (r *rawEventXML) getKeywords() string          { return r.Keywords }
+func (r *rawEventXML) getVersion() uint8            { return r.Version }
+func (r *rawEventXML) getBinaryEventData() string   { return r.BinaryEventData }
+func (r *rawEventXML) getEventData() EventData      { return r.EventData }
+func (r *rawEventXML) getUserData() *UserData       { return r.UserData }
+
 func (r *rawEventXML) getRenderedLevel() string {
 	if r.RenderingInfo != nil {
 		return r.RenderingInfo.Level
+	}
+	return ""
+}
+func (r *rawEventXML) getRenderedMessage() string {
+	if r.RenderingInfo != nil {
+		return r.RenderingInfo.Message
+	}
+	return ""
+}
+func (r *rawEventXML) getRenderedTask() string {
+	if r.RenderingInfo != nil {
+		return r.RenderingInfo.Task
+	}
+	return ""
+}
+func (r *rawEventXML) getRenderedOpcode() string {
+	if r.RenderingInfo != nil {
+		return r.RenderingInfo.Opcode
+	}
+	return ""
+}
+func (r *rawEventXML) getRenderedKeywords() []string {
+	if r.RenderingInfo != nil {
+		return r.RenderingInfo.Keywords
+	}
+	return nil
+}
+func (r *rawEventXML) getUserID() string {
+	if r.Security != nil {
+		return r.Security.UserID
+	}
+	return ""
+}
+func (r *rawEventXML) getProcessID() uint {
+	if r.Execution != nil {
+		return r.Execution.ProcessID
+	}
+	return 0
+}
+func (r *rawEventXML) getThreadID() uint {
+	if r.Execution != nil {
+		return r.Execution.ThreadID
+	}
+	return 0
+}
+func (r *rawEventXML) getActivityID() string {
+	if r.Correlation != nil && r.Correlation.ActivityID != nil {
+		return *r.Correlation.ActivityID
+	}
+	return ""
+}
+func (r *rawEventXML) getRelatedActivityID() string {
+	if r.Correlation != nil && r.Correlation.RelatedActivityID != nil {
+		return *r.Correlation.RelatedActivityID
 	}
 	return ""
 }
@@ -546,14 +765,16 @@ func unmarshalRawEventXML(data []byte) (parsedEvent, error) {
 	return &raw, nil
 }
 
-// sanitizeXMLBytes removes characters that are illegal in XML 1.0 documents.
+// sanitizeXMLBytes removes characters that are illegal in XML 1.0 documents
+// and strips the default XML namespace to allow Go's xml package to parse
+// Windows Event Log XML correctly.
 // XML 1.0 permits: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
 // All other code points (e.g. U+0001–U+0008, U+000B, U+000C, U+000E–U+001F) are dropped.
-//
-// A zero-allocation pre-scan is performed first; if no illegal bytes are found
-// the original slice is returned unchanged, avoiding the bytes.Map allocation
-// on the common (clean) path.
 func sanitizeXMLBytes(data []byte) []byte {
+	// Strip default namespace to allow Go xml package to parse correctly
+	// Pattern: xmlns='...' or xmlns="..."
+	data = stripDefaultNamespace(data)
+
 	if !hasIllegalXMLBytes(data) {
 		return data
 	}
@@ -565,6 +786,43 @@ func sanitizeXMLBytes(data []byte) []byte {
 		}
 		return -1
 	}, data)
+}
+
+// stripDefaultNamespace removes xmlns='...' or xmlns="..." from the XML
+// to allow Go's xml package to parse without namespace qualification issues.
+func stripDefaultNamespace(data []byte) []byte {
+	// Look for xmlns= patterns and remove them
+	// Pattern 1: xmlns='...'
+	// Pattern 2: xmlns="..."
+	result := data
+
+	// Handle xmlns='...'
+	if idx := bytes.Index(result, []byte("xmlns='")); idx >= 0 {
+		endIdx := bytes.Index(result[idx+7:], []byte("'"))
+		if endIdx >= 0 {
+			// Remove xmlns='...' including trailing space if present
+			endPos := idx + 7 + endIdx + 1
+			if endPos < len(result) && result[endPos] == ' ' {
+				endPos++
+			}
+			result = append(result[:idx], result[endPos:]...)
+		}
+	}
+
+	// Handle xmlns="..."
+	if idx := bytes.Index(result, []byte("xmlns=\"")); idx >= 0 {
+		endIdx := bytes.Index(result[idx+7:], []byte("\""))
+		if endIdx >= 0 {
+			// Remove xmlns="..." including trailing space if present
+			endPos := idx + 7 + endIdx + 1
+			if endPos < len(result) && result[endPos] == ' ' {
+				endPos++
+			}
+			result = append(result[:idx], result[endPos:]...)
+		}
+	}
+
+	return result
 }
 
 // hasIllegalXMLBytes reports whether data contains any character that is

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -22,11 +22,11 @@ type EventXML struct {
 	Channel             string               `xml:"System>Channel"`
 	RecordID            uint64               `xml:"System>EventRecordID"`
 	TimeCreated         TimeCreated          `xml:"System>TimeCreated"`
-	Message          string       `xml:"RenderingInfo>Message"`
-	RenderedLevel    string       `xml:"RenderingInfo>Level"`
-	RenderedTask     string       `xml:"RenderingInfo>Task"`
-	RenderedOpcode   string       `xml:"RenderingInfo>Opcode"`
-	RenderedKeywords []string     `xml:"RenderingInfo>Keywords>Keyword"`
+	Message             string               `xml:"RenderingInfo>Message"`
+	RenderedLevel       string               `xml:"RenderingInfo>Level"`
+	RenderedTask        string               `xml:"RenderingInfo>Task"`
+	RenderedOpcode      string               `xml:"RenderingInfo>Opcode"`
+	RenderedKeywords    []string             `xml:"RenderingInfo>Keywords>Keyword"`
 	Level               string               `xml:"System>Level"`
 	Task                string               `xml:"System>Task"`
 	Opcode              string               `xml:"System>Opcode"`
@@ -53,22 +53,25 @@ func parseTimestamp(ts string) time.Time {
 	return time.Now()
 }
 
-// parseRenderedSeverity will parse the severity of the event.
+// parseSeverity will parse the severity of the event.
+// Prefers numeric level (more reliable across localized Windows installations)
+// over rendered text, falling back to text when numeric is unavailable.
 func parseSeverity(renderedLevel, level string) entry.Severity {
+	// Prefer numeric level first (more reliable than localized text)
+	switch level {
+	case "1":
+		return entry.Fatal
+	case "2":
+		return entry.Error
+	case "3":
+		return entry.Warn
+	case "4":
+		return entry.Info
+	case "5":
+		return entry.Debug // Verbose
+	}
+	// Fallback to rendered text when numeric level is empty/unknown
 	switch renderedLevel {
-	case "":
-		switch level {
-		case "1":
-			return entry.Fatal
-		case "2":
-			return entry.Error
-		case "3":
-			return entry.Warn
-		case "4":
-			return entry.Info
-		default:
-			return entry.Default
-		}
 	case "Critical":
 		return entry.Fatal
 	case "Error":
@@ -77,9 +80,8 @@ func parseSeverity(renderedLevel, level string) entry.Severity {
 		return entry.Warn
 	case "Information":
 		return entry.Info
-	default:
-		return entry.Default
 	}
+	return entry.Default
 }
 
 // formattedBody will parse a body from the event.

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -29,16 +29,31 @@ func TestParseInvalidTimestamp(t *testing.T) {
 }
 
 func TestParseSeverity(t *testing.T) {
+	// Numeric level takes precedence over rendered text
+	require.Equal(t, entry.Fatal, parseSeverity("Information", "1")) // numeric wins
+	require.Equal(t, entry.Error, parseSeverity("Information", "2")) // numeric wins
+	require.Equal(t, entry.Warn, parseSeverity("Information", "3"))  // numeric wins
+	require.Equal(t, entry.Info, parseSeverity("Error", "4"))        // numeric wins
+	require.Equal(t, entry.Debug, parseSeverity("Error", "5"))       // numeric wins (Verbose)
+
+	// Numeric level only (no rendered text)
+	require.Equal(t, entry.Fatal, parseSeverity("", "1"))
+	require.Equal(t, entry.Error, parseSeverity("", "2"))
+	require.Equal(t, entry.Warn, parseSeverity("", "3"))
+	require.Equal(t, entry.Info, parseSeverity("", "4"))
+	require.Equal(t, entry.Debug, parseSeverity("", "5"))
+
+	// Fallback to rendered text when numeric level is empty/unknown
 	require.Equal(t, entry.Fatal, parseSeverity("Critical", ""))
 	require.Equal(t, entry.Error, parseSeverity("Error", ""))
 	require.Equal(t, entry.Warn, parseSeverity("Warning", ""))
 	require.Equal(t, entry.Info, parseSeverity("Information", ""))
 	require.Equal(t, entry.Default, parseSeverity("Unknown", ""))
-	require.Equal(t, entry.Fatal, parseSeverity("", "1"))
-	require.Equal(t, entry.Error, parseSeverity("", "2"))
-	require.Equal(t, entry.Warn, parseSeverity("", "3"))
-	require.Equal(t, entry.Info, parseSeverity("", "4"))
+
+	// Default when both are unknown/empty
 	require.Equal(t, entry.Default, parseSeverity("", "0"))
+	require.Equal(t, entry.Default, parseSeverity("", ""))
+	require.Equal(t, entry.Default, parseSeverity("Unknown", "99"))
 }
 
 func TestParseBody(t *testing.T) {


### PR DESCRIPTION
- Improved the windowsevent to support latest otel version (v0.152)
- Enhance windowsevent to classify the level based on numeric value
- Optimized the fallback implementation when (agent don't have direct connection to opsramp) via proxy tunnel
- log improvement & bug fixes 